### PR TITLE
Fix up parsing more complex sources..list lines

### DIFF
--- a/lib/charms/operator_libs_linux/v0/apt.py
+++ b/lib/charms/operator_libs_linux/v0/apt.py
@@ -1168,9 +1168,16 @@ class RepositoryMapping(Mapping):
           file: the path to the repository file
         """
         f = open(file, "r")
+        parsed_any = False
         for n, line in enumerate(f):
-            repo = self._parse(line, file)
-            self._repository_map[f"{repo.repotype}-{repo.uri}-{repo.release}"] = repo
+            try:
+                repo = self._parse(line, file)
+                self._repository_map[f"{repo.repotype}-{repo.uri}-{repo.release}"] = repo
+                parsed_any = True
+            except InvalidSourceError:
+                logger.debug("Skipping invalid line {} in {}".format(line, file))
+        if not parsed_any:
+            raise InvalidSourceError("All repository lines in {} were invalid!".format(file))
 
     @staticmethod
     def _parse(line: str, filename: str) -> DebianRepository:

--- a/lib/charms/operator_libs_linux/v0/apt.py
+++ b/lib/charms/operator_libs_linux/v0/apt.py
@@ -36,9 +36,9 @@ try:
     apt.add_package("zsh")
     apt.add_package(["vim", "htop", "wget"])
 except PackageNotFoundError:
-    logger.error("A specified package not found in package cache or on system")
+    logger.error("a specified package not found in package cache or on system")
 except PackageError as e:
-    logger.error(f"Could not install package. Reason: {e.message}")
+    logger.error("could not install package. Reason: %s", e.message)
 ````
 
 To find details of a specific package:
@@ -54,11 +54,11 @@ try:
     # apt.DebianPackage.from_installed_package("vim")
 
     vim.ensure(PackageState.Latest)
-    logger.info(f"Updated vim to {vim.fullversion}")
+    logger.info("updated vim to version: %s", vim.fullversion)
 except PackageNotFoundError:
-    logger.error("A specified package not found in package cache or on system")
+    logger.error("a specified package not found in package cache or on system")
 except PackageError as e:
-    logger.error(f"Could not install package. Reason: {e.message}")
+    logger.error("could not install package. Reason: %s", e.message)
 ```
 
 
@@ -128,6 +128,7 @@ LIBPATCH = 2
 
 
 VALID_SOURCE_TYPES = ("deb", "deb-src")
+OPTIONS_MATCHER = re.compile(r"\[.*?\]")
 
 
 class Error(Exception):
@@ -367,7 +368,7 @@ class DebianPackage:
             return DebianPackage.from_installed_package(package, version, arch)
         except PackageNotFoundError:
             logger.debug(
-                f"Package {package} is not currently installed or has the wrong architecture."
+                "package '%s' is not currently installed or has the wrong architecture.", package
             )
 
         # Ok, try `apt-cache ...`
@@ -434,7 +435,7 @@ class DebianPackage:
                 if pkg.arch == arch and (version == "" or str(pkg.version) == version):
                     return pkg
             except AttributeError:
-                logger.warning(f"dpkg matcher could not parse line: {line}")
+                logger.warning("dpkg matcher could not parse line: %s", line)
 
         # If we didn't find it, fail through
         raise PackageNotFoundError(f"Package {package}.{arch} is not installed!")
@@ -742,11 +743,11 @@ def add_package(
         if success:
             packages["success"].append(pkg)
         else:
-            logger.warning(f"Failed to locate and install/update {pkg}!")
+            logger.warning("failed to locate and install/update '%s'", pkg)
             packages["retry"].append(p)
 
     if packages["retry"] and not cache_refreshed:
-        logger.info("Updating the apt-cache and retrying installation of failed packages.")
+        logger.info("updating the apt-cache and retrying installation of failed packages.")
         update()
 
         for p in packages["retry"]:
@@ -808,7 +809,7 @@ def remove_package(
             pkg.ensure(state=PackageState.Absent)
             packages.append(pkg)
         except PackageNotFoundError:
-            logger.info(f"Package {p} was requested for removal, but it was not installed.")
+            logger.info("package '%s' was requested for removal, but it was not installed.", p)
 
     return packages if len(packages) > 1 else packages[0]
 
@@ -1161,23 +1162,34 @@ class RepositoryMapping(Mapping):
         """Add a `DebianRepository` to the cache."""
         self._repository_map[repository_uri] = repository
 
-    def load(self, file: str):
+    def load(self, filename: str):
         """Load a repository source file into the cache.
 
         Args:
-          file: the path to the repository file
+          filename: the path to the repository file
         """
-        f = open(file, "r")
-        parsed_any = False
-        for n, line in enumerate(f):
-            try:
-                repo = self._parse(line, file)
-                self._repository_map[f"{repo.repotype}-{repo.uri}-{repo.release}"] = repo
-                parsed_any = True
-            except InvalidSourceError:
-                logger.debug("Skipping invalid line {} in {}".format(line, file))
-        if not parsed_any:
-            raise InvalidSourceError("All repository lines in {} were invalid!".format(file))
+        parsed = []
+        skipped = []
+        with open(filename, "r") as f:
+            for n, line in enumerate(f):
+                try:
+                    repo = self._parse(line, filename)
+                except InvalidSourceError:
+                    skipped.append(n)
+                else:
+                    repo_identifier = f"{repo.repotype}-{repo.uri}-{repo.release}"
+                    self._repository_map[repo_identifier] = repo
+                    parsed.append(n)
+                    logger.debug("parsed repo: '%s'", repo_identifier)
+
+        if skipped:
+            skip_list = ", ".join(str(s) for s in skipped)
+            logger.debug("skipped the following lines in file '%s': %s", filename, skip_list)
+
+        if parsed:
+            logger.info("parsed %d apt package repositories", len(parsed))
+        else:
+            raise InvalidSourceError("all repository lines in '{}' were invalid!".format(filename))
 
     @staticmethod
     def _parse(line: str, filename: str) -> DebianRepository:
@@ -1188,13 +1200,11 @@ class RepositoryMapping(Mapping):
           filename: the filename being read
 
         Raises:
-          InvalidSoureError if the source type is unknown
+          InvalidSourceError if the source type is unknown
         """
         enabled = True
         repotype = uri = release = gpg_key = ""
-
         options = {}
-        options_matcher = re.compile(r"\[.*?\]")
         groups = []
 
         line = line.strip()
@@ -1210,27 +1220,31 @@ class RepositoryMapping(Mapping):
         # Split a source into substrings to initialize a new repo.
         source = line.strip()
         if source:
-            for v in re.findall(options_matcher, source):
+            # Match any repo options, and get a dict representation.
+            for v in re.findall(OPTIONS_MATCHER, source):
                 opts = dict(o.split("=") for o in v.strip("[]").split())
-
-                if "signed-by" in opts:
-                    gpg_key = opts["signed-by"]
-                    del opts["signed-by"]
+                # Extract the 'signed-by' option for the gpg_key
+                gpg_key = opts.pop("signed-by", "")
                 options = opts
-            if re.search(options_matcher, source):
-                source = re.sub(options_matcher, "", source)
 
+            # Remove any options from the source string and split the string into chunks
+            source = re.sub(OPTIONS_MATCHER, "", source)
             chunks = source.split()
-            if chunks[0] not in VALID_SOURCE_TYPES:
+
+            # Check we've got a valid list of chunks
+            if len(chunks) < 3 or chunks[0] not in VALID_SOURCE_TYPES:
                 raise InvalidSourceError("An invalid sources line was found in %s!", filename)
+
             repotype = chunks[0]
             uri = chunks[1]
             release = chunks[2]
             groups = chunks[3:]
 
-        return DebianRepository(
-            enabled, repotype, uri, release, groups, filename, gpg_key, options
-        )
+            return DebianRepository(
+                enabled, repotype, uri, release, groups, filename, gpg_key, options
+            )
+        else:
+            raise InvalidSourceError("An invalid sources line was found in %s!", filename)
 
     def add(self, repo: DebianRepository, default_filename: Optional[bool] = True) -> None:
         """Add a new repository to the system.
@@ -1241,7 +1255,7 @@ class RepositoryMapping(Mapping):
         """
         if repo.filename and default_filename:
             logger.error(
-                "Cannot add a repository with a default filename and a "
+                "cannot add a repository with a default filename and a "
                 "filename set in the `DebianRepository` object"
             )
 

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -107,3 +107,20 @@ class TestRepositoryMapping(TestCase):
             "deb https://example.com/foo focal bar baz\n",
             open(d.filename).readlines(),
         )
+
+    def test_can_add_repositories_from_string_with_options(self):
+        d = apt.DebianRepository.from_repo_line(
+            "deb [signed-by=/foo/gpg.key arch=amd64] https://example.com/foo focal bar baz"
+        )
+        self.assertEqual(d.enabled, True)
+        self.assertEqual(d.repotype, "deb")
+        self.assertEqual(d.uri, "https://example.com/foo")
+        self.assertEqual(d.release, "focal")
+        self.assertEqual(d.groups, ["bar", "baz"])
+        self.assertEqual(d.filename, "foo-focal.list")
+        self.assertEqual(d.gpg_key, "/foo/gpg.key")
+        self.assertEqual(d.options["arch"], "amd64")
+        self.assertIn(
+            "deb [arch=amd64 signed-by=/foo/gpg.key] https://example.com/foo focal bar baz\n",
+            open(d.filename).readlines(),
+        )

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -6,7 +6,9 @@ from pyfakefs.fake_filesystem_unittest import TestCase
 
 sources_list = """## This is a comment which should be ignored!
 deb http://us.archive.ubuntu.com/ubuntu focal main restricted universe multiverse
+
 deb http://us.archive.ubuntu.com/ubuntu focal-updates main restricted universe multiverse
+
 # deb http://us.archive.ubuntu.com/ubuntu focal-backports main restricted universe multiverse
 """
 
@@ -61,7 +63,9 @@ class TestRepositoryMapping(TestCase):
         self.assertEqual(
             "<charms.operator_libs_linux.v0.apt.InvalidSourceError>", ctx.exception.name
         )
-        self.assertIn("All repository lines in /tmp/bad.list", ctx.exception.message)
+        self.assertIn(
+            "all repository lines in '/tmp/bad.list' were invalid!", ctx.exception.message
+        )
 
     def test_can_disable_repositories(self):
         r = apt.RepositoryMapping()

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -4,7 +4,8 @@
 from charms.operator_libs_linux.v0 import apt
 from pyfakefs.fake_filesystem_unittest import TestCase
 
-sources_list = """deb http://us.archive.ubuntu.com/ubuntu focal main restricted universe multiverse
+sources_list = """## This is a comment which should be ignored!
+deb http://us.archive.ubuntu.com/ubuntu focal main restricted universe multiverse
 deb http://us.archive.ubuntu.com/ubuntu focal-updates main restricted universe multiverse
 # deb http://us.archive.ubuntu.com/ubuntu focal-backports main restricted universe multiverse
 """
@@ -60,7 +61,7 @@ class TestRepositoryMapping(TestCase):
         self.assertEqual(
             "<charms.operator_libs_linux.v0.apt.InvalidSourceError>", ctx.exception.name
         )
-        self.assertIn("An invalid sources line", ctx.exception.message)
+        self.assertIn("All repository lines in /tmp/bad.list", ctx.exception.message)
 
     def test_can_disable_repositories(self):
         r = apt.RepositoryMapping()

--- a/tests/test_snap.py
+++ b/tests/test_snap.py
@@ -191,7 +191,7 @@ class TestSnapCache(unittest.TestCase):
     @patch("os.path.isfile")
     def test_can_load_snap_cache(self, mock_exists, m):
         m.return_value.__iter__ = lambda self: self
-        m.return_value.__next__ = lambda self: next(iter(self.readline, ''))
+        m.return_value.__next__ = lambda self: next(iter(self.readline, ""))
         mock_exists.return_value = True
         s = SnapCacheTester()
         s._load_available_snaps()
@@ -202,7 +202,7 @@ class TestSnapCache(unittest.TestCase):
     @patch("os.path.isfile")
     def test_can_lazy_load_snap_info(self, mock_exists, m):
         m.return_value.__iter__ = lambda self: self
-        m.return_value.__next__ = lambda self: next(iter(self.readline, ''))
+        m.return_value.__next__ = lambda self: next(iter(self.readline, ""))
         mock_exists.return_value = True
         s = SnapCacheTester()
         s._snap_client.get_snap_information.return_value = json.loads(lazy_load_result)["result"][
@@ -296,7 +296,7 @@ class TestSnapBareMethods(unittest.TestCase):
     @patch("os.path.isfile")
     def setUp(self, mock_exists, m):
         m.return_value.__iter__ = lambda self: self
-        m.return_value.__next__ = lambda self: next(iter(self.readline, ''))
+        m.return_value.__next__ = lambda self: next(iter(self.readline, ""))
         mock_exists.return_value = True
         snap._Cache.cache = SnapCacheTester()
         snap._Cache.cache._snap_client.get_installed_snaps.return_value = json.loads(

--- a/tests/test_snap.py
+++ b/tests/test_snap.py
@@ -187,16 +187,22 @@ class SnapCacheTester(snap.SnapCache):
 
 
 class TestSnapCache(unittest.TestCase):
-    @patch("builtins.open", mock_open(read_data="foo\nbar\n"))
-    def test_can_load_snap_cache(self):
+    @patch("builtins.open", new_callable=mock_open, read_data="foo\nbar\n")
+    @patch("os.path.isfile")
+    def test_can_load_snap_cache(self, mock_exists, m):
+        m.return_value.__iter__ = lambda self: self
+        m.return_value.__next__ = lambda self: next(iter(self.readline, ''))
+        mock_exists.return_value = True
         s = SnapCacheTester()
         s._load_available_snaps()
         self.assertIn("foo", s._snap_map)
         self.assertEqual(len(s._snap_map), 2)
 
-    @patch("builtins.open", mock_open(read_data="curl\n"))
+    @patch("builtins.open", new_callable=mock_open, read_data="curl\n")
     @patch("os.path.isfile")
-    def test_can_lazy_load_snap_info(self, mock_exists):
+    def test_can_lazy_load_snap_info(self, mock_exists, m):
+        m.return_value.__iter__ = lambda self: self
+        m.return_value.__next__ = lambda self: next(iter(self.readline, ''))
         mock_exists.return_value = True
         s = SnapCacheTester()
         s._snap_client.get_snap_information.return_value = json.loads(lazy_load_result)["result"][
@@ -286,7 +292,12 @@ class TestSocketClient(unittest.TestCase):
 
 
 class TestSnapBareMethods(unittest.TestCase):
-    def setUp(self):
+    @patch("builtins.open", new_callable=mock_open, read_data="curl\n")
+    @patch("os.path.isfile")
+    def setUp(self, mock_exists, m):
+        m.return_value.__iter__ = lambda self: self
+        m.return_value.__next__ = lambda self: next(iter(self.readline, ''))
+        mock_exists.return_value = True
         snap._Cache.cache = SnapCacheTester()
         snap._Cache.cache._snap_client.get_installed_snaps.return_value = json.loads(
             installed_result


### PR DESCRIPTION
For options other than `signed-by`, parse them out into a dict so we they can be set appropriate and we don't fail. There's a surprisingly long list of options here, and while most are not relevant enough to expose, we shouldn't fail, either.

Don't raise `InvalidSourceError` unless the entire file fails to parse. This didn't come up in development since the LXD 20;04 image also has all comments stripped out of `sources.list` files.