### PR TITLE
Check whether snap is installed at all, and catalog presence

### DIFF
--- a/lib/charms/operator_libs_linux/v0/snap.py
+++ b/lib/charms/operator_libs_linux/v0/snap.py
@@ -505,6 +505,8 @@ class SnapCache(Mapping):
     """
 
     def __init__(self):
+        if not self.snapd_installed:
+            raise SnapError("snapd is not installed or not in /usr/bin") from None
         self._snap_client = SnapClient()
         self._snap_map = {}
         if self.snapd_installed:
@@ -525,9 +527,6 @@ class SnapCache(Mapping):
 
     def __getitem__(self, snap_name: str) -> Snap:
         """Return either the installed version or latest version for a given snap."""
-        if not self.snapd_installed:
-            raise SnapError("snapd is not installed or not in /usr/bin") from None
-
         snap = None
         try:
             snap = self._snap_map[snap_name]

--- a/lib/charms/operator_libs_linux/v0/snap.py
+++ b/lib/charms/operator_libs_linux/v0/snap.py
@@ -507,8 +507,9 @@ class SnapCache(Mapping):
     def __init__(self):
         self._snap_client = SnapClient()
         self._snap_map = {}
-        self._load_available_snaps()
-        self._load_installed_snaps()
+        if self.snapd_installed:
+            self._load_available_snaps()
+            self._load_installed_snaps()
 
     def __contains__(self, key: str) -> bool:
         """Magic method to ease checking if a given snap is in the cache."""
@@ -524,16 +525,32 @@ class SnapCache(Mapping):
 
     def __getitem__(self, snap_name: str) -> Snap:
         """Return either the installed version or latest version for a given snap."""
+        if not self.snapd_installed:
+            raise SnapError("snapd is not installed or not in /usr/bin") from None
+
+        snap = None
         try:
             snap = self._snap_map[snap_name]
         except KeyError:
-            raise SnapNotFoundError(f"Snap '{snap_name}' not found in cache!")
+            # The snap catalog may not be populated yet. Try to fetch info
+            # blindly
+            logger.warning(
+                "Snap '{}' not found in the snap cache. "
+                "The catalog may not be populated by snapd yet".format(snap_name)
+            )
 
         if snap is None:
-            self._snap_map[snap_name] = self._load_info(snap_name)
-            return self._snap_map[snap_name]
+            try:
+                self._snap_map[snap_name] = self._load_info(snap_name)
+            except SnapAPIError:
+                raise SnapNotFoundError(f"Snap '{snap_name}' not found!")
 
         return self._snap_map[snap_name]
+
+    @property
+    def snapd_installed(self) -> bool:
+        """Check whether snapd has been installled on the system."""
+        return os.path.isfile("/usr/bin/snap")
 
     def _load_available_snaps(self) -> None:
         """Load the list of available snaps from disk.

--- a/tests/test_snap.py
+++ b/tests/test_snap.py
@@ -230,6 +230,15 @@ class TestSnapCache(unittest.TestCase):
         self.assertEqual(s["charmcraft"].revision, "603")
 
     @patch("os.path.isfile")
+    def test_raises_error_if_snap_not_installed(self, mock_exists):
+        mock_exists.return_value = False
+        s = SnapCacheTester()
+        with self.assertRaises(snap.SnapError) as ctx:
+            s["snapcraft"]
+        self.assertEqual("<charms.operator_libs_linux.v0.snap.SnapError>", ctx.exception.name)
+        self.assertIn("snapd is not installed", ctx.exception.message)
+
+    @patch("os.path.isfile")
     def test_raises_error_if_snap_not_running(self, mock_exists):
         mock_exists.return_value = False
         s = SnapCacheTester()

--- a/tests/test_snap.py
+++ b/tests/test_snap.py
@@ -230,15 +230,6 @@ class TestSnapCache(unittest.TestCase):
         self.assertEqual(s["charmcraft"].revision, "603")
 
     @patch("os.path.isfile")
-    def test_raises_error_if_snap_not_installed(self, mock_exists):
-        mock_exists.return_value = False
-        s = SnapCacheTester()
-        with self.assertRaises(snap.SnapError) as ctx:
-            s["snapcraft"]
-        self.assertEqual("<charms.operator_libs_linux.v0.snap.SnapError>", ctx.exception.name)
-        self.assertIn("snapd is not installed", ctx.exception.message)
-
-    @patch("os.path.isfile")
     def test_raises_error_if_snap_not_running(self, mock_exists):
         mock_exists.return_value = False
         s = SnapCacheTester()


### PR DESCRIPTION
Throw a `SnapError` if `snapd` isn't installed, to provide more
meaningful feedback to users.

`snapd` does not always populate the catalog in
`/var/cache/snapd/names` at install time, especially if it's
installed/started as part of `cloud-init`, in a container, or
somewhere else where networking may not be available at first
run.

The snapd API doesn't provide a convenient way to refresh this,
and restarting the service is undesirable. Instead, if a requested
package isn't in the cache, blindly try the `snap` API to see if
we can fetch info for the requested package and return a
`SnapNotFoundError` if we get a `SnapAPIError`