### PR TITLE
Use python builtin modules instead of hand-parsing for passwd

### DIFF
--- a/lib/charms/operator_libs_linux/v0/passwd.py
+++ b/lib/charms/operator_libs_linux/v0/passwd.py
@@ -266,6 +266,7 @@ class User(object):
                 args.append("-r")
 
             subprocess.check_call(["useradd", *args, self.name])
+            self._uid = self._uid or int(pwd.getpwnam(self.name).pw_uid)
         except CalledProcessError as e:
             raise UserError(f"Could not add user '{self.name}' to the system: {e.output}")
 
@@ -320,7 +321,7 @@ class User(object):
                 found = True if user.pw_passwd == "!" else False
             else:
                 found = True if user.pw_passwd == "x" else False
-        except KeyError:
+        except (TypeError, KeyError):
             logger.debug("User {} does not exist on the system.".format(self.name))
             found = False
 
@@ -405,6 +406,7 @@ class Group(object):
             if self.gid:
                 cmd.extend(["-g", f"{self.gid}"])
             subprocess.check_call(cmd)
+            self._gid = self._gid or int(grp.getgrnam(self.name).gr_gid)
         except CalledProcessError as e:
             raise GroupError(f"Could not add group {self.name}! Reason: {e.output}")
 

--- a/tests/unit/test_passwd.py
+++ b/tests/unit/test_passwd.py
@@ -1,20 +1,59 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import grp
+import pwd
 from unittest.mock import patch
 
 from charms.operator_libs_linux.v0 import passwd
 from pyfakefs.fake_filesystem_unittest import TestCase
 
+pwd_getpw_return = [
+    pwd.struct_passwd(
+        (
+            "systemd-coredump",
+            "x",
+            "999",
+            "999",
+            "systemd Core Dumper",
+            "/",
+            "/usr/sbin/nologin",
+        )
+    ),
+    pwd.struct_passwd(
+        (
+            "testuser",
+            "x",
+            "1000",
+            "1000",
+            "",
+            "/home/testuser",
+            "/usr/bin/bash",
+        )
+    ),
+    pwd.struct_passwd(
+        (
+            "lxd",
+            "x",
+            "998",
+            "118",
+            "",
+            "/var/snap/lxd/common/lxd",
+            "/bin/false",
+        )
+    ),
+]
+
+grp_getgr_return = [
+    grp.struct_group(("lxd", "x", "118", ["testuser"])),
+    grp.struct_group(("systemd-coredump", "x", "999", [])),
+    grp.struct_group(("testuser", "x", "1000", [])),
+    grp.struct_group(("microk8s", "x", "998", ["testuser"])),
+]
+
 etc_passwd = """systemd-coredump:x:999:999:systemd Core Dumper:/:/usr/sbin/nologin
 testuser:x:1000:1000::/home/testuser:/usr/bin/bash
 lxd:x:998:118::/var/snap/lxd/common/lxd:/bin/false
-"""
-
-etc_group = """lxd:x:118:testuser
-systemd-coredump:x:999:
-testuser:x:1000:
-microk8s:x:998:testuser
 """
 
 etc_shadow = """
@@ -28,30 +67,49 @@ class TestPasswd(TestCase):
     def setUp(self):
         self.setUpPyfakefs()
         self.fs.create_file("/etc/passwd", contents=etc_passwd)
-        self.fs.create_file("/etc/group", contents=etc_group)
 
-    def test_can_load_groups(self):
+    @patch("pwd.getpwall")
+    @patch("grp.getgrall")
+    def test_can_load_groups(self, mock_grp, mock_pw):
+        mock_grp.return_value = grp_getgr_return
+        mock_pw.return_value = pwd_getpw_return
         p = passwd.Passwd()
         self.assertIn("testuser", p.groups)
         self.assertEqual(len(p.groups), 4)
 
-    def test_lookup_group_by_gid(self):
+    @patch("pwd.getpwall")
+    @patch("grp.getgrall")
+    def test_lookup_group_by_gid(self, mock_grp, mock_pw):
+        mock_grp.return_value = grp_getgr_return
+        mock_pw.return_value = pwd_getpw_return
         p = passwd.Passwd()
         lxd_group = passwd.Passwd.lookup_group(118)
         self.assertEqual(p.groups["lxd"], lxd_group)
 
-    def test_lookup_group_by_name(self):
+    @patch("pwd.getpwall")
+    @patch("grp.getgrall")
+    def test_lookup_group_by_name(self, mock_grp, mock_pw):
+        mock_grp.return_value = grp_getgr_return
+        mock_pw.return_value = pwd_getpw_return
         p = passwd.Passwd()
         lxd_group = passwd.Passwd.lookup_group("lxd")
         self.assertEqual(p.groups["lxd"], lxd_group)
 
-    def test_lookup_group_raises_type_error(self):
+    @patch("pwd.getpwall")
+    @patch("grp.getgrall")
+    def test_lookup_group_raises_type_error(self, mock_grp, mock_pw):
+        mock_grp.return_value = grp_getgr_return
+        mock_pw.return_value = pwd_getpw_return
         invalid = [False, passwd.Group("foo", []), 37.55]
         for x in invalid:
             with self.assertRaises(TypeError):
                 passwd.Passwd.lookup_group(x)
 
-    def test_can_get_group_details(self):
+    @patch("pwd.getpwall")
+    @patch("grp.getgrall")
+    def test_can_get_group_details(self, mock_grp, mock_pw):
+        mock_grp.return_value = grp_getgr_return
+        mock_pw.return_value = pwd_getpw_return
         p = passwd.Passwd()
         group = p.groups["lxd"]
 
@@ -59,7 +117,11 @@ class TestPasswd(TestCase):
         self.assertEqual(group.gid, 118)
         self.assertEqual(group.users[0].name, "testuser")
 
-    def test_raises_error_on_group_not_found(self):
+    @patch("pwd.getpwall")
+    @patch("grp.getgrall")
+    def test_raises_error_on_group_not_found(self, mock_grp, mock_pw):
+        mock_grp.return_value = grp_getgr_return
+        mock_pw.return_value = pwd_getpw_return
         p = passwd.Passwd()
 
         with self.assertRaises(passwd.GroupNotFoundError) as ctx:
@@ -70,12 +132,20 @@ class TestPasswd(TestCase):
         )
         self.assertIn("Group 'nothere' not found", ctx.exception.message)
 
-    def test_can_load_users(self):
+    @patch("pwd.getpwall")
+    @patch("grp.getgrall")
+    def test_can_load_users(self, mock_grp, mock_pw):
+        mock_grp.return_value = grp_getgr_return
+        mock_pw.return_value = pwd_getpw_return
         p = passwd.Passwd()
         self.assertIn("systemd-coredump", p.users)
         self.assertEqual(len(p.users), 3)
 
-    def test_can_get_user_details(self):
+    @patch("pwd.getpwall")
+    @patch("grp.getgrall")
+    def test_can_get_user_details(self, mock_grp, mock_pw):
+        mock_grp.return_value = grp_getgr_return
+        mock_pw.return_value = pwd_getpw_return
         p = passwd.Passwd()
         u = p.users["systemd-coredump"]
         self.assertEqual(u.name, "systemd-coredump")
@@ -85,23 +155,39 @@ class TestPasswd(TestCase):
         self.assertEqual(u.homedir, "/")
         self.assertEqual(u.state, passwd.UserState.NoLogin)
 
-    def test_lookup_user_by_uid(self):
+    @patch("pwd.getpwall")
+    @patch("grp.getgrall")
+    def test_lookup_user_by_uid(self, mock_grp, mock_pw):
+        mock_grp.return_value = grp_getgr_return
+        mock_pw.return_value = pwd_getpw_return
         p = passwd.Passwd()
         lxd_user = passwd.Passwd.lookup_user(998)
         self.assertEqual(p.users["lxd"], lxd_user)
 
-    def test_lookup_user_by_name(self):
+    @patch("pwd.getpwall")
+    @patch("grp.getgrall")
+    def test_lookup_user_by_name(self, mock_grp, mock_pw):
+        mock_grp.return_value = grp_getgr_return
+        mock_pw.return_value = pwd_getpw_return
         p = passwd.Passwd()
         lxd_user = passwd.Passwd.lookup_user("lxd")
         self.assertEqual(p.users["lxd"], lxd_user)
 
-    def test_lookup_user_raises_type_error(self):
+    @patch("pwd.getpwall")
+    @patch("grp.getgrall")
+    def test_lookup_user_raises_type_error(self, mock_grp, mock_pw):
+        mock_grp.return_value = grp_getgr_return
+        mock_pw.return_value = pwd_getpw_return
         invalid = [False, passwd.Group("foo", []), 37.55]
         for x in invalid:
             with self.assertRaises(TypeError):
                 passwd.Passwd.lookup_user(x)
 
-    def test_raises_error_on_user_not_found(self):
+    @patch("pwd.getpwall")
+    @patch("grp.getgrall")
+    def test_raises_error_on_user_not_found(self, mock_grp, mock_pw):
+        mock_grp.return_value = grp_getgr_return
+        mock_pw.return_value = pwd_getpw_return
         p = passwd.Passwd()
 
         with self.assertRaises(passwd.UserNotFoundError) as ctx:
@@ -112,8 +198,12 @@ class TestPasswd(TestCase):
         )
         self.assertIn("User 'nothere' not found", ctx.exception.message)
 
+    @patch("pwd.getpwall")
+    @patch("grp.getgrall")
     @patch("charms.operator_libs_linux.v0.passwd.subprocess.check_call")
-    def test_can_ensure_user_state(self, mock_subprocess):
+    def test_can_ensure_user_state(self, mock_subprocess, mock_grp, mock_pw):
+        mock_grp.return_value = grp_getgr_return
+        mock_pw.return_value = pwd_getpw_return
         mock_subprocess.return_value = 0
         p = passwd.Passwd()
 
@@ -127,8 +217,12 @@ class TestPasswd(TestCase):
         v.ensure_state(passwd.UserState.NoLogin)
         mock_subprocess.assert_called_with(["usermod", "-s", "/sbin/nologin", v.name])
 
+    @patch("pwd.getpwall")
+    @patch("grp.getgrall")
     @patch("charms.operator_libs_linux.v0.passwd.subprocess.check_call")
-    def test_can_add_users_and_groups(self, mock_subprocess):
+    def test_can_add_users_and_groups(self, mock_subprocess, mock_grp, mock_pw):
+        mock_grp.return_value = grp_getgr_return
+        mock_pw.return_value = pwd_getpw_return
         mock_subprocess.return_value = 0
         p = passwd.Passwd()
 

--- a/tests/unit/test_passwd.py
+++ b/tests/unit/test_passwd.py
@@ -217,12 +217,14 @@ class TestPasswd(TestCase):
         v.ensure_state(passwd.UserState.NoLogin)
         mock_subprocess.assert_called_with(["usermod", "-s", "/sbin/nologin", v.name])
 
+    @patch("pwd.getpwuid")
     @patch("pwd.getpwall")
     @patch("grp.getgrall")
     @patch("charms.operator_libs_linux.v0.passwd.subprocess.check_call")
-    def test_can_add_users_and_groups(self, mock_subprocess, mock_grp, mock_pw):
+    def test_can_add_users_and_groups(self, mock_subprocess, mock_grp, mock_pw, mock_getuid):
         mock_grp.return_value = grp_getgr_return
         mock_pw.return_value = pwd_getpw_return
+        mock_getuid.side_effect = KeyError
         mock_subprocess.return_value = 0
         p = passwd.Passwd()
 


### PR DESCRIPTION
The `pwd` and `grp` modules are very API-stable. Use those to
parse contents instead of regular expressions