### PR TITLE
Feature/set multiple config vals

### DIFF
--- a/lib/charms/operator_libs_linux/v0/snap.py
+++ b/lib/charms/operator_libs_linux/v0/snap.py
@@ -77,11 +77,11 @@ logger = logging.getLogger(__name__)
 LIBID = "05394e5893f94f2d90feb7cbe6b633cd"
 
 # Increment this major API version when introducing breaking changes
-LIBAPI = 0
+LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 
 def _cache_init(func):

--- a/lib/charms/operator_libs_linux/v0/snap.py
+++ b/lib/charms/operator_libs_linux/v0/snap.py
@@ -34,7 +34,7 @@ try:
 
     if not juju.present:
         juju.ensure(snap.SnapState.Latest, channel="beta")
-        juju.set(key="value", key2="value2")
+        juju.set({"some.key": "value", "some.key2": "value2"})
 except snap.SnapError as e:
     logger.error("An exception occurred when installing charmcraft. Reason: %s", e.message)
 ```
@@ -50,7 +50,7 @@ As an example of installing several Snaps and checking details:
 try:
     nextcloud, charmcraft = snap.add(["nextcloud", "charmcraft"])
     if nextcloud.get("mode") != "production":
-        nextcloud.set(mode="production")
+        nextcloud.set({"mode": "production"})
 except snap.SnapError as e:
     logger.error("An exception occurred when installing snaps. Reason: %s", e.message)
 ```

--- a/lib/charms/operator_libs_linux/v0/snap.py
+++ b/lib/charms/operator_libs_linux/v0/snap.py
@@ -250,14 +250,13 @@ class Snap(object):
         """
         return self._snap("get", [key])
 
-    def set(self, **kwargs) -> str:
+    def set(self, config: dict[str:str]) -> str:
         """Sets a snap configuration value.
 
         Args:
-            key: the key to set
-            value: the value to set it to
+           config: a dictionary containing keys and values specifying the config to set.
         """
-        args = [f'{key}="{val}"' for key, val in kwargs.items()]
+        args = [f'{key}="{val}"' for key, val in config.items()]
 
         return self._snap("set", [*args])
 

--- a/lib/charms/operator_libs_linux/v0/snap.py
+++ b/lib/charms/operator_libs_linux/v0/snap.py
@@ -250,14 +250,16 @@ class Snap(object):
         """
         return self._snap("get", [key])
 
-    def set(self, key, value) -> str:
+    def set(self, **kwargs) -> str:
         """Sets a snap configuration value.
 
         Args:
             key: the key to set
             value: the value to set it to
         """
-        return self._snap("set", [key, value])
+        args = [f'{key}={val}' for key, val in kwargs]
+            
+        return self._snap("set", *args])
 
     def unset(self, key) -> str:
         """Unsets a snap configuration value.

--- a/lib/charms/operator_libs_linux/v0/snap.py
+++ b/lib/charms/operator_libs_linux/v0/snap.py
@@ -256,7 +256,7 @@ class Snap(object):
         Args:
            config: a dictionary containing keys and values specifying the config to set.
         """
-        args = [f'{key}="{val}"' for key, val in config.items()]
+        args = ['{}="{}"'.format(key, val) for key, val in config.items()]
 
         return self._snap("set", [*args])
 

--- a/lib/charms/operator_libs_linux/v0/snap.py
+++ b/lib/charms/operator_libs_linux/v0/snap.py
@@ -248,7 +248,7 @@ class Snap(object):
         Args:
             key: the key to retrieve
         """
-        return self._snap("get", [key])
+        return self._snap("get", [key]).strip()
 
     def set(self, config: Dict) -> str:
         """Sets a snap configuration value.

--- a/lib/charms/operator_libs_linux/v0/snap.py
+++ b/lib/charms/operator_libs_linux/v0/snap.py
@@ -250,7 +250,7 @@ class Snap(object):
         """
         return self._snap("get", [key])
 
-    def set(self, config: dict[str:str]) -> str:
+    def set(self, config: Dict) -> str:
         """Sets a snap configuration value.
 
         Args:

--- a/lib/charms/operator_libs_linux/v0/snap.py
+++ b/lib/charms/operator_libs_linux/v0/snap.py
@@ -34,7 +34,7 @@ try:
 
     if not juju.present:
         juju.ensure(snap.SnapState.Latest, channel="beta")
-        juju.set("key", "value")
+        juju.set(key="value", key2="value2")
 except snap.SnapError as e:
     logger.error("An exception occurred when installing charmcraft. Reason: %s", e.message)
 ```
@@ -50,7 +50,7 @@ As an example of installing several Snaps and checking details:
 try:
     nextcloud, charmcraft = snap.add(["nextcloud", "charmcraft"])
     if nextcloud.get("mode") != "production":
-        nextcloud.set("mode", "production")
+        nextcloud.set(mode="production")
 except snap.SnapError as e:
     logger.error("An exception occurred when installing snaps. Reason: %s", e.message)
 ```
@@ -257,9 +257,9 @@ class Snap(object):
             key: the key to set
             value: the value to set it to
         """
-        args = [f'{key}={val}' for key, val in kwargs]
-            
-        return self._snap("set", *args])
+        args = [f'{key}="{val}"' for key, val in kwargs.items()]
+
+        return self._snap("set", [*args])
 
     def unset(self, key) -> str:
         """Unsets a snap configuration value.

--- a/tests/integration/test_snap.py
+++ b/tests/integration/test_snap.py
@@ -53,8 +53,6 @@ def test_snap_set():
     lxd = cache["lxd"]
     lxd.ensure(snap.SnapState.Latest, channel="latest")
 
-    import os
-
     lxd.set({"ceph.external": "false", "criu.enable": "false"})
 
     assert lxd.get("ceph.external") == "false"

--- a/tests/integration/test_snap.py
+++ b/tests/integration/test_snap.py
@@ -49,7 +49,9 @@ def test_snap_refresh():
 
 
 def test_snap_set():
-    lxd = snap.ensure(["lxd"], snap.SnapState.Latest, channel="stable")
+    cache = snap.SnapCache()
+    lxd = cache["lxd"]
+    lxd.ensure(snap.SnapState.Latest, channel="stable")  # The settings below are in 4.20+
 
     assert lxd.get("ceph.external") == "false"
     assert lxd.get("criu.enable") == "false"
@@ -61,7 +63,9 @@ def test_snap_set():
 
 
 def test_unset_key_raises_snap_error():
-    lxd = snap.ensure(["lxd"], snap.SnapState.Latest, channel="stable")
+    cache = snap.SnapCache()
+    lxd = cache["lxd"]
+    lxd.ensure(snap.SnapState.Latest, channel="stable")
 
     # Verify that the correct exception gets raised in the case of an unset key.
     key = "keythatdoesntexist01"

--- a/tests/integration/test_snap.py
+++ b/tests/integration/test_snap.py
@@ -49,7 +49,7 @@ def test_snap_refresh():
 
 
 def test_snap_set():
-    lxd = snap.ensure(["lxd"], snap.SnapState.Latest, channel="latest/stable")
+    lxd = snap.ensure(["lxd"], snap.SnapState.Latest, channel="stable")
 
     assert lxd.get("ceph.external") == "false"
     assert lxd.get("criu.enable") == "false"
@@ -61,7 +61,7 @@ def test_snap_set():
 
 
 def test_unset_key_raises_snap_error():
-    lxd = snap.ensure("lxd")
+    lxd = snap.ensure(["lxd"], snap.SnapState.Latest, channel="stable")
 
     # Verify that the correct exception gets raised in the case of an unset key.
     key = "keythatdoesntexist01"

--- a/tests/integration/test_snap.py
+++ b/tests/integration/test_snap.py
@@ -79,8 +79,8 @@ def test_unset_key_raises_snap_error():
         logger.error("Getting an unset key should result in a SnapError.")
 
     # We can make the above work w/ abitrary config.
-    assert lxd.set({key: "true"})
-    assert lxd.get(key)
+    lxd.set({key: "true"})
+    assert lxd.get(key) == "true"
 
 
 def test_snap_ensure():

--- a/tests/integration/test_snap.py
+++ b/tests/integration/test_snap.py
@@ -58,3 +58,20 @@ def test_snap_set():
 
     assert lxd.get("ceph.external") == "true"
     assert lxd.get("criu.enable") == "true"
+
+
+def test_unset_key_raises_snap_error():
+    lxd = snap.ensure("lxd")
+
+    # Verify that the correct exception gets raised in the case of an unset key.
+    key = "keythatdoesntexist01"
+    try:
+        lxd.get(key)
+    except snap.SnapError:
+        pass
+    else:
+        logger.error("Setting an unset key should result in a SnapError.")
+
+    # We can make the above work w/ abitrary config.
+    assert lxd.set({key: "true"})
+    assert lxd.get(key)

--- a/tests/integration/test_snap.py
+++ b/tests/integration/test_snap.py
@@ -46,3 +46,15 @@ def test_snap_refresh():
     cache = snap.SnapCache()
     lxd = cache["lxd"]
     lxd.ensure(snap.SnapState.Latest, classic=False, channel="latest/candidate", cohort="+")
+
+
+def test_snap_set():
+    lxd = snap.ensure(["lxd"], snap.SnapState.Latest, channel="latest/stable")
+
+    assert lxd.get("ceph.external") == "false"
+    assert lxd.get("criu.enable") == "false"
+
+    lxd.set({"ceph.external": "true", "criu.enable": "true"})
+
+    assert lxd.get("ceph.external") == "true"
+    assert lxd.get("criu.enable") == "true"

--- a/tests/integration/test_snap.py
+++ b/tests/integration/test_snap.py
@@ -51,7 +51,11 @@ def test_snap_refresh():
 def test_snap_set():
     cache = snap.SnapCache()
     lxd = cache["lxd"]
-    lxd.ensure(snap.SnapState.Latest, channel="stable")  # The settings below are in 4.20+
+    lxd.ensure(snap.SnapState.Latest, channel="latest")
+
+    import os
+
+    lxd.set({"ceph.external": "false", "criu.enable": "false"})
 
     assert lxd.get("ceph.external") == "false"
     assert lxd.get("criu.enable") == "false"
@@ -65,7 +69,7 @@ def test_snap_set():
 def test_unset_key_raises_snap_error():
     cache = snap.SnapCache()
     lxd = cache["lxd"]
-    lxd.ensure(snap.SnapState.Latest, channel="stable")
+    lxd.ensure(snap.SnapState.Latest, channel="latest")
 
     # Verify that the correct exception gets raised in the case of an unset key.
     key = "keythatdoesntexist01"
@@ -79,3 +83,13 @@ def test_unset_key_raises_snap_error():
     # We can make the above work w/ abitrary config.
     assert lxd.set({key: "true"})
     assert lxd.get(key)
+
+
+def test_snap_ensure():
+    cache = snap.SnapCache()
+    charmcraft = cache["charmcraft"]
+
+    # Verify that we can run ensure multiple times in a row without delays.
+    charmcraft.ensure(snap.SnapState.Latest, channel="latest/stable")
+    charmcraft.ensure(snap.SnapState.Latest, channel="latest/stable")
+    charmcraft.ensure(snap.SnapState.Latest, channel="latest/stable")

--- a/tests/integration/test_snap.py
+++ b/tests/integration/test_snap.py
@@ -70,7 +70,7 @@ def test_unset_key_raises_snap_error():
     except snap.SnapError:
         pass
     else:
-        logger.error("Setting an unset key should result in a SnapError.")
+        logger.error("Getting an unset key should result in a SnapError.")
 
     # We can make the above work w/ abitrary config.
     assert lxd.set({key: "true"})

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -386,3 +386,20 @@ class TestSnapBareMethods(unittest.TestCase):
             snap.add("nothere")
         self.assertEqual("<charms.operator_libs_linux.v0.snap.SnapError>", ctx.exception.name)
         self.assertIn("Failed to install or refresh snap(s): nothere", ctx.exception.message)
+
+    @patch("charms.operator_libs_linux.v0.snap.subprocess.check_output")
+    def test_snap_set(self, mock_subprocess):
+
+        foo = snap.Snap("foo", snap.SnapState.Present, "stable", "1", "classic")
+
+        foo.set(bar="baz")
+        mock_subprocess.assert_called_with(
+            ["snap", "set", "foo", 'bar="baz"'],
+            universal_newlines=True,
+        )
+
+        foo.set(bar="baz", qux="quux")
+        mock_subprocess.assert_called_with(
+            ["snap", "set", "foo", 'bar="baz"', 'qux="quux"'],
+            universal_newlines=True,
+        )

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -392,13 +392,13 @@ class TestSnapBareMethods(unittest.TestCase):
 
         foo = snap.Snap("foo", snap.SnapState.Present, "stable", "1", "classic")
 
-        foo.set(bar="baz")
+        foo.set({"bar": "baz"})
         mock_subprocess.assert_called_with(
             ["snap", "set", "foo", 'bar="baz"'],
             universal_newlines=True,
         )
 
-        foo.set(bar="baz", qux="quux")
+        foo.set({"bar": "baz", "qux": "quux"})
         mock_subprocess.assert_called_with(
             ["snap", "set", "foo", 'bar="baz"', 'qux="quux"'],
             universal_newlines=True,

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -399,7 +399,8 @@ class TestSnapBareMethods(unittest.TestCase):
         )
 
         foo.set({"bar": "baz", "qux": "quux"})
-        mock_subprocess.assert_called_with(
-            ["snap", "set", "foo", 'bar="baz"', 'qux="quux"'],
-            universal_newlines=True,
-        )
+        latest_args = mock_subprocess.call_args_list[-1].args[0]
+        self.assertEqual(["snap", "set", "foo"], latest_args[:3])
+        # Order of the settings can vary, and is specifically different in Python 3.5.
+        self.assertTrue('bar="baz"' in latest_args)
+        self.assertTrue('qux="quux"' in latest_args)

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -399,8 +399,16 @@ class TestSnapBareMethods(unittest.TestCase):
         )
 
         foo.set({"bar": "baz", "qux": "quux"})
-        latest_args = mock_subprocess.call_args_list[-1].args[0]
-        self.assertEqual(["snap", "set", "foo"], latest_args[:3])
-        # Order of the settings can vary, and is specifically different in Python 3.5.
-        self.assertTrue('bar="baz"' in latest_args)
-        self.assertTrue('qux="quux"' in latest_args)
+        try:
+            mock_subprocess.assert_called_with(
+                ["snap", "set", "foo", 'bar="baz"', 'qux="quux"'],
+                universal_newlines=True,
+            )
+        except AssertionError:
+            # The ordering of this call can be unpredictable across Python verisons.
+            # Unfortunately, the methods available to introspect the call list have also
+            # changed, so we do this, which is a little clunky.
+            mock_subprocess.assert_called_with(
+                ["snap", "set", "foo", 'qux="quux"', 'bar="baz"'],
+                universal_newlines=True,
+            )


### PR DESCRIPTION
This breaks backwards compatibility by changing the way that snap.set and snap.get work.

I think that's okay, however, as this is a new library with no known users as of yet. And maintaining backwards compatibility with keys that contain dot notation would be difficult.