### PR TITLE
Make service and popen_kwargs 'private'; driveby spelling fix

### DIFF
--- a/lib/charms/operator_libs_linux/v0/systemd.py
+++ b/lib/charms/operator_libs_linux/v0/systemd.py
@@ -63,7 +63,7 @@ LIBAPI = 0
 LIBPATCH = 1
 
 
-def popen_kwargs():
+def _popen_kwargs():
     return dict(
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
@@ -73,12 +73,12 @@ def popen_kwargs():
     )
 
 
-def service(action: str, service_name: str, now: bool = None, quiet: bool = None) -> bool:
+def _service(action: str, service_name: str, now: bool = None, quiet: bool = None) -> bool:
     """Control a system service.
 
     Args:
         action: the action to take on the service
-        service_name: the name of the service to perform th action on
+        service_name: the name of the service to perform the action on
         now: passes the --now flag to the shell invocation.
         quiet: passes the --quiet flag to the shell invocation.
     """
@@ -92,7 +92,7 @@ def service(action: str, service_name: str, now: bool = None, quiet: bool = None
     else:
         logger.debug("Checking if '{}' is active".format(service_name))
 
-    proc = subprocess.Popen(cmd, **popen_kwargs())
+    proc = subprocess.Popen(cmd, **_popen_kwargs())
     for line in iter(proc.stdout.readline, ""):
         logger.debug(line)
 
@@ -106,7 +106,7 @@ def service_running(service_name: str) -> bool:
     Args:
         service_name: the name of the service
     """
-    return service("is-active", service_name, quiet=True)
+    return _service("is-active", service_name, quiet=True)
 
 
 def service_start(service_name: str) -> bool:
@@ -115,7 +115,7 @@ def service_start(service_name: str) -> bool:
     Args:
         service_name: the name of the service to stop
     """
-    return service("start", service_name)
+    return _service("start", service_name)
 
 
 def service_stop(service_name: str) -> bool:
@@ -124,7 +124,7 @@ def service_stop(service_name: str) -> bool:
     Args:
         service_name: the name of the service to stop
     """
-    return service("stop", service_name)
+    return _service("stop", service_name)
 
 
 def service_restart(service_name: str) -> bool:
@@ -133,7 +133,7 @@ def service_restart(service_name: str) -> bool:
     Args:
         service_name: the name of the service to restart
     """
-    return service("restart", service_name)
+    return _service("restart", service_name)
 
 
 def service_reload(service_name: str, restart_on_failure: bool = False) -> bool:
@@ -144,9 +144,9 @@ def service_reload(service_name: str, restart_on_failure: bool = False) -> bool:
         restart_on_failure: boolean indicating whether to fallback to a restart if the
           reload fails.
     """
-    service_result = service("reload", service_name)
+    service_result = _service("reload", service_name)
     if not service_result and restart_on_failure:
-        service_result = service("restart", service_name)
+        service_result = _service("restart", service_name)
     return service_result
 
 
@@ -158,8 +158,8 @@ def service_pause(service_name: str) -> bool:
     Args:
         service_name: the name of the service to pause
     """
-    service("disable", service_name, now=True)
-    service("mask", service_name)
+    _service("disable", service_name, now=True)
+    _service("mask", service_name)
     return not service_running(service_name)
 
 
@@ -171,6 +171,6 @@ def service_resume(service_name: str) -> bool:
     Args:
         service_name: the name of the service to resume
     """
-    service("unmask", service_name)
-    service("enable", service_name, now=True)
+    _service("unmask", service_name)
+    _service("enable", service_name, now=True)
     return service_running(service_name)

--- a/lib/charms/operator_libs_linux/v0/systemd.py
+++ b/lib/charms/operator_libs_linux/v0/systemd.py
@@ -60,7 +60,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 
 def _popen_kwargs():

--- a/tests/unit/test_systemd.py
+++ b/tests/unit/test_systemd.py
@@ -17,7 +17,7 @@ def with_mock_subp(func):
 
     The function returns the mock Popen object, so that routines such as
     assert_called_with can be called upon it, along with the return from
-    systemd.popen_kwargs, for convenience when composing call objects.
+    systemd._popen_kwargs, for convenience when composing call objects.
 
     """
 
@@ -40,7 +40,7 @@ def with_mock_subp(func):
             mock_popen = mock_subp.Popen
             mock_popen.side_effect = tuple(side_effects)
 
-            return mock_popen, systemd.popen_kwargs()
+            return mock_popen, systemd._popen_kwargs()
 
         func(cls, make_mock_popen)
 
@@ -52,11 +52,11 @@ class TestSystemD(unittest.TestCase):
     def test_service(self, make_mock):
         mockp, kw = make_mock([0, 1])
 
-        success = systemd.service("is-active", "mysql")
+        success = systemd._service("is-active", "mysql")
         mockp.assert_called_with(["systemctl", "is-active", "mysql"], **kw)
         self.assertTrue(success)
 
-        success = systemd.service("is-active", "mysql")
+        success = systemd._service("is-active", "mysql")
         mockp.assert_called_with(["systemctl", "is-active", "mysql"], **kw)
         self.assertFalse(success)
 


### PR DESCRIPTION
As title suggests, this makes some internal details 'private' by prefixing their name with `_`.

Fixes #26 