### PR TITLE
Add missing closing bracket from apt docstring, and update logging formatting in snap docstring to match guidelines

### DIFF
--- a/lib/charms/operator_libs_linux/v0/apt.py
+++ b/lib/charms/operator_libs_linux/v0/apt.py
@@ -45,7 +45,7 @@ To find details of a specific package:
 
 ```python
 try:
-    vim = apt.DebianPackage.from_system("vim"
+    vim = apt.DebianPackage.from_system("vim")
 
     # To find from the apt cache only
     # apt.DebianPackage.from_apt_cache("vim")

--- a/lib/charms/operator_libs_linux/v0/snap.py
+++ b/lib/charms/operator_libs_linux/v0/snap.py
@@ -36,7 +36,7 @@ try:
         juju.ensure(snap.SnapState.Latest, channel="beta")
         juju.set("key", "value")
 except snap.SnapError as e:
-    logger.error(f"An exception occurred when installing charmcraft. Reason: {e.message}")
+    logger.error("An exception occurred when installing charmcraft. Reason: %s", e.message)
 ```
 
 In addition, the `snap` module provides "bare" methods which can act on Snap packages as
@@ -52,7 +52,7 @@ try:
     if nextcloud.get("mode") != "production":
         nextcloud.set("mode", "production")
 except snap.SnapError as e:
-    logger.error(f"An exception occurred when installing snaps. Reason: {e.message}")
+    logger.error("An exception occurred when installing snaps. Reason: %s", e.message)
 ```
 """
 


### PR DESCRIPTION
A trivial change to add missing closing bracket in the `apt.py` docstring, and update logging formatting in the `snap.py` docstring to match guidelines per https://juju.is/docs/sdk/styleguide#heading--logging.