### PR TITLE
Add support for Python 3.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,9 +15,16 @@ jobs:
   unit-test:
     name: Unit tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: python -m pip install tox
       - name: Run tests

--- a/lib/charms/operator_libs_linux/v0/apt.py
+++ b/lib/charms/operator_libs_linux/v0/apt.py
@@ -136,12 +136,12 @@ class Error(Exception):
 
     def __repr__(self):
         """String representation of Error."""
-        return f"<{type(self).__module__}.{type(self).__name__} {self.args}>"
+        return "<{}.{} {}>".format(type(self).__module__, type(self).__name__, self.args)
 
     @property
     def name(self):
         """Return a string representation of the model plus class."""
-        return f"<{type(self).__module__}.{type(self).__name__}>"
+        return "<{}.{}>".format(type(self).__module__, type(self).__name__)
 
     @property
     def message(self):
@@ -221,7 +221,7 @@ class DebianPackage:
 
     def __repr__(self):
         """A representation of the package."""
-        return f"<{self.__module__}.{self.__class__.__name__}: {self.__dict__}>"
+        return "<{}.{}: {}>".format(self.__module__, self.__class__.__name__, self.__dict__)
 
     def __str__(self):
         """A human-readable representation of the package."""
@@ -257,20 +257,20 @@ class DebianPackage:
             check_call(_cmd, stderr=PIPE, stdout=PIPE)
         except CalledProcessError as e:
             raise PackageError(
-                f"Could not {command} package(s) [{[*package_names]}]: {e.output}"
+                "Could not {} package(s) [{}]: {}".format(command, [*package_names], e.output)
             ) from None
 
     def _add(self) -> None:
         """Add a package to the system."""
         self._apt(
             "install",
-            f"{self.name}={self.version}",
+            "{}={}".format(self.name, self.version),
             optargs=["--option=Dpkg::Options::=--force-confold"],
         )
 
     def _remove(self) -> None:
         """Removes a package from the system. Implementation-specific."""
-        return self._apt("remove", f"{self.name}={self.version}")
+        return self._apt("remove", "{}={}".format(self.name, self.version))
 
     @property
     def name(self) -> str:
@@ -342,7 +342,7 @@ class DebianPackage:
     @property
     def fullversion(self) -> str:
         """Returns the name+epoch for a package."""
-        return f"{self._version}.{self._arch}"
+        return "{}.{}".format(self._version, self._arch)
 
     @staticmethod
     def _get_epoch_from_version(version: str) -> Tuple[str, str]:
@@ -379,7 +379,9 @@ class DebianPackage:
             # This seems unnecessary, but virtually all `apt` commands have a return code of `100`,
             # and providing meaningful error messages without this is ugly.
             raise PackageNotFoundError(
-                f"Package '{package}{f'.{arch}' if arch else ''}' could not be found on the system or in the apt cache!"
+                "Package '{}{}' could not be found on the system or in the apt cache!".format(
+                    package, ".{}".format(arch) if arch else ""
+                )
             ) from None
 
     @classmethod
@@ -404,7 +406,7 @@ class DebianPackage:
         try:
             output = check_output(["dpkg", "-l", package], stderr=PIPE, universal_newlines=True)
         except CalledProcessError:
-            raise PackageNotFoundError(f"Package is not installed: {package}") from None
+            raise PackageNotFoundError("Package is not installed: {}".format(package)) from None
 
         # Pop off the output from `dpkg -l' because there's no flag to
         # omit it`
@@ -438,7 +440,7 @@ class DebianPackage:
                 logger.warning("dpkg matcher could not parse line: %s", line)
 
         # If we didn't find it, fail through
-        raise PackageNotFoundError(f"Package {package}.{arch} is not installed!")
+        raise PackageNotFoundError("Package {}.{} is not installed!".format(package, arch))
 
     @classmethod
     def from_apt_cache(
@@ -465,7 +467,9 @@ class DebianPackage:
                 ["apt-cache", "show", package], stderr=PIPE, universal_newlines=True
             )
         except CalledProcessError as e:
-            raise PackageError(f"Could not list packages in apt-cache: {e.output}") from None
+            raise PackageError(
+                "Could not list packages in apt-cache: {}".format(e.output)
+            ) from None
 
         pkg_groups = output.strip().split("\n\n")
         keys = ("Package", "Architecture", "Version")
@@ -493,7 +497,7 @@ class DebianPackage:
                 return pkg
 
         # If we didn't find it, fail through
-        raise PackageNotFoundError(f"Package {package}.{arch} is not in the apt cache!")
+        raise PackageNotFoundError("Package {}.{} is not in the apt cache!".format(package, arch))
 
 
 class Version:
@@ -512,11 +516,11 @@ class Version:
 
     def __repr__(self):
         """A representation of the package."""
-        return f"<{self.__module__}.{self.__class__.__name__}: {self.__dict__}>"
+        return "<{}.{}: {}>".format(self.__module__, self.__class__.__name__, self.__dict__)
 
     def __str__(self):
         """A human-readable representation of the package."""
-        return f"{f'{self._epoch}:' if self._epoch else ''}{self._version}"
+        return "{}{}".format("{}:".format(self._epoch) if self._epoch else "", self._version)
 
     @property
     def epoch(self):
@@ -760,7 +764,7 @@ def add_package(
                 packages["failed"].append(p)
 
     if packages["failed"]:
-        raise PackageError(f"Failed to install packages: {', '.join(packages['failed'])}")
+        raise PackageError("Failed to install packages: {}".format(", ".join(packages["failed"])))
 
     return packages["success"] if len(packages["success"]) > 1 else packages["success"][0]
 
@@ -914,7 +918,11 @@ class DebianRepository:
         if self._gpg_key_filename:
             options["signed-by"] = self._gpg_key_filename
 
-        return f"[{' '.join([f'{k}={v}' for k,v in options.items()])}] " if options else ""
+        return (
+            "[{}] ".format(" ".join(["{}={}".format(k, v) for k, v in options.items()]))
+            if options
+            else ""
+        )
 
     @staticmethod
     def prefix_from_uri(uri: str) -> str:
@@ -923,7 +931,7 @@ class DebianRepository:
         path = (
             uridetails.path.lstrip("/").replace("/", "-") if uridetails.path else uridetails.netloc
         )
-        return f"/etc/apt/sources.list.d/{path}"
+        return "/etc/apt/sources.list.d/{}".format(path)
 
     @staticmethod
     def from_repo_line(repo_line: str, write_file: Optional[bool] = True) -> "DebianRepository":
@@ -934,8 +942,8 @@ class DebianRepository:
             write_file: boolean to enable writing the new repo to disk
         """
         repo = RepositoryMapping._parse(repo_line, "UserInput")
-        fname = (
-            f"{DebianRepository.prefix_from_uri(repo.uri)}-{repo.release.replace('/', '-')}.list"
+        fname = "{}-{}.list".format(
+            DebianRepository.prefix_from_uri(repo.uri), repo.release.replace("/", "-")
         )
         repo.filename = fname
 
@@ -943,14 +951,20 @@ class DebianRepository:
         if repo.gpg_key:
             options["signed-by"] = repo.gpg_key
 
-        options_str = f"[{' '.join([f'{k}={v}' for k,v in options.items()])}] " if options else ""
+        options_str = (
+            "[{}] ".format(" ".join(["{}={}".format(k, v) for k, v in options.items()]))
+            if options
+            else ""
+        )
 
         if write_file:
             with open(fname, "wb") as f:
                 f.write(
-                    f"{'#' if not repo.enabled else ''}"
-                    f"{repo.repotype} {options_str}{repo.uri} "
-                    f"{repo.release} {' '.join(repo.groups)}\n".encode("utf-8")
+                    (
+                        "{}".format("#" if not repo.enabled else "")
+                        + "{} {}{} ".format(repo.repotype, options_str, repo.uri)
+                        + "{} {}\n".format(repo.release, " ".join(repo.groups))
+                    ).encode("utf-8")
                 )
 
         return repo
@@ -960,10 +974,12 @@ class DebianRepository:
 
         Disable it instead of removing from the repository file.
         """
-        searcher = f"{self.repotype} {self.make_options_string()}{self.uri} {self.release}"
+        searcher = "{} {}{} {}".format(
+            self.repotype, self.make_options_string(), self.uri, self.release
+        )
         for line in fileinput.input(self._filename, inplace=True):
-            if re.match(rf"^{re.escape(searcher)}\s", line):
-                print(f"# {line}", end="")
+            if re.match(r"^{}\s".format(re.escape(searcher)), line):
+                print("# {}".format(line), end="")
             else:
                 print(line, end="")
 
@@ -1000,7 +1016,7 @@ class DebianRepository:
                 key_bytes = key.encode("utf-8")
                 key_name = self._get_keyid_by_gpg_key(key_bytes)
                 key_gpg = self._dearmor_gpg_key(key_bytes)
-                self._gpg_key_filename = f"/etc/apt/trusted.gpg.d/{key_name}.gpg"
+                self._gpg_key_filename = "/etc/apt/trusted.gpg.d/{}.gpg".format(key_name)
                 self._write_apt_gpg_keyfile(key_name=self._gpg_key_filename, key_material=key_gpg)
             else:
                 raise GPGKeyError("ASCII armor markers missing from GPG key")
@@ -1018,7 +1034,7 @@ class DebianRepository:
             key_asc = self._get_key_by_keyid(key)
             # write the key in GPG format so that apt-key list shows it
             key_gpg = self._dearmor_gpg_key(key_asc.encode("utf-8"))
-            self._gpg_key_filename = f"/etc/apt/trusted.gpg.d/{key}.gpg"
+            self._gpg_key_filename = "/etc/apt/trusted.gpg.d/{}.gpg".format(key)
             self._write_apt_gpg_keyfile(key_name=key, key_material=key_gpg)
 
     @staticmethod
@@ -1183,7 +1199,7 @@ class RepositoryMapping(Mapping):
                 except InvalidSourceError:
                     skipped.append(n)
                 else:
-                    repo_identifier = f"{repo.repotype}-{repo.uri}-{repo.release}"
+                    repo_identifier = "{}-{}-{}".format(repo.repotype, repo.uri, repo.release)
                     self._repository_map[repo_identifier] = repo
                     parsed.append(n)
                     logger.debug("parsed repo: '%s'", repo_identifier)
@@ -1259,8 +1275,8 @@ class RepositoryMapping(Mapping):
           repo: a `DebianRepository` object
           default_filename: an (Optional) filename if the default is not desirable
         """
-        new_filename = (
-            f"{DebianRepository.prefix_from_uri(repo.uri)}-{repo.release.replace('/', '-')}.list"
+        new_filename = "{}-{}.list".format(
+            DebianRepository.prefix_from_uri(repo.uri), repo.release.replace("/", "-")
         )
 
         fname = repo.filename or new_filename
@@ -1271,12 +1287,14 @@ class RepositoryMapping(Mapping):
 
         with open(fname, "wb") as f:
             f.write(
-                f"{'#' if not repo.enabled else ''}"
-                f"{repo.repotype} {repo.make_options_string()}{repo.uri} "
-                f"{repo.release} {' '.join(repo.groups)}\n".encode("utf-8")
+                (
+                    "{}".format("#" if not repo.enabled else "")
+                    + "{} {}{} ".format(repo.repotype, repo.make_options_string(), repo.uri)
+                    + "{} {}\n".format(repo.release, " ".join(repo.groups))
+                ).encode("utf-8")
             )
 
-        self._repository_map[f"{repo.repotype}-{repo.uri}-{repo.release}"] = repo
+        self._repository_map["{}-{}-{}".format(repo.repotype, repo.uri, repo.release)] = repo
 
     def disable(self, repo: DebianRepository) -> None:
         """Remove a repository. Disable by default.
@@ -1284,12 +1302,14 @@ class RepositoryMapping(Mapping):
         Args:
           repo: a `DebianRepository` to disable
         """
-        searcher = f"{repo.repotype} {repo.make_options_string()}{repo.uri} {repo.release}"
+        searcher = "{} {}{} {}".format(
+            repo.repotype, repo.make_options_string(), repo.uri, repo.release
+        )
 
         for line in fileinput.input(repo.filename, inplace=True):
-            if re.match(rf"^{re.escape(searcher)}\s", line):
-                print(f"# {line}", end="")
+            if re.match(r"^{}\s".format(re.escape(searcher)), line):
+                print("# {}".format(line), end="")
             else:
                 print(line, end="")
 
-        self._repository_map[f"{repo.repotype}-{repo.uri}-{repo.release}"] = repo
+        self._repository_map["{}-{}-{}".format(repo.repotype, repo.uri, repo.release)] = repo

--- a/lib/charms/operator_libs_linux/v0/apt.py
+++ b/lib/charms/operator_libs_linux/v0/apt.py
@@ -951,8 +951,10 @@ class DebianRepository:
         if repo.gpg_key:
             options["signed-by"] = repo.gpg_key
 
+        # For Python 3.5 it's required to use sorted in the options dict in order to not have
+        # different results in the order of the options between executions.
         options_str = (
-            "[{}] ".format(" ".join(["{}={}".format(k, v) for k, v in options.items()]))
+            "[{}] ".format(" ".join(["{}={}".format(k, v) for k, v in sorted(options.items())]))
             if options
             else ""
         )

--- a/lib/charms/operator_libs_linux/v0/apt.py
+++ b/lib/charms/operator_libs_linux/v0/apt.py
@@ -124,7 +124,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 
 VALID_SOURCE_TYPES = ("deb", "deb-src")

--- a/lib/charms/operator_libs_linux/v0/snap.py
+++ b/lib/charms/operator_libs_linux/v0/snap.py
@@ -120,12 +120,12 @@ class Error(Exception):
 
     def __repr__(self):
         """String representation of the Error class."""
-        return f"<{type(self).__module__}.{type(self).__name__} {self.args}>"
+        return "<{}.{} {}>".format(type(self).__module__, type(self).__name__, self.args)
 
     @property
     def name(self):
         """Return a string representation of the model plus class."""
-        return f"<{type(self).__module__}.{type(self).__name__}>"
+        return "<{}.{}>".format(type(self).__module__, type(self).__name__)
 
     @property
     def message(self):
@@ -205,7 +205,7 @@ class Snap(object):
 
     def __repr__(self):
         """A representation of the snap."""
-        return f"<{self.__module__}.{self.__class__.__name__}: {self.__dict__}>"
+        return "<{}.{}: {}>".format(self.__module__, self.__class__.__name__, self.__dict__)
 
     def __str__(self):
         """A human-readable representation of the snap."""
@@ -267,7 +267,7 @@ class Snap(object):
           channel: the channel to install from
         """
         confinement = "--classic" if self._confinement == "classic" else ""
-        channel = f'--channel="{channel}"' if channel else ""
+        channel = '--channel="{}"'.format(channel) if channel else ""
         self._snap("install", [confinement, channel])
 
     def _refresh(self, channel: Optional[str] = "") -> None:
@@ -276,7 +276,7 @@ class Snap(object):
         Args:
           channel: the channel to install from
         """
-        channel = f"--{channel}" if channel else self._channel
+        channel = "--{}".format(channel) if channel else self._channel
         self._snap("refresh", [channel])
 
     def _remove(self) -> None:
@@ -370,7 +370,7 @@ class _UnixSocketConnection(http.client.HTTPConnection):
     def connect(self):
         """Override connect to use Unix socket (instead of TCP socket)."""
         if not hasattr(socket, "AF_UNIX"):
-            raise NotImplementedError(f"Unix sockets not supported on {sys.platform}")
+            raise NotImplementedError("Unix sockets not supported on {}".format(sys.platform))
         self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self.sock.connect(self.socket_path)
         if self.timeout is not None:
@@ -480,7 +480,7 @@ class SnapClient:
             except (IOError, ValueError, KeyError) as e2:
                 # Will only happen on read error or if Pebble sends invalid JSON.
                 body = {}
-                message = f"{type(e2).__name__} - {e2}"
+                message = "{} - {}".format(type(e2).__name__, e2)
             raise SnapAPIError(body, code, status, message)
         except urllib.error.URLError as e:
             raise SnapAPIError({}, 500, "Not found", e.reason)
@@ -542,7 +542,7 @@ class SnapCache(Mapping):
             try:
                 self._snap_map[snap_name] = self._load_info(snap_name)
             except SnapAPIError:
-                raise SnapNotFoundError(f"Snap '{snap_name}' not found!")
+                raise SnapNotFoundError("Snap '{}' not found!".format(snap_name))
 
         return self._snap_map[snap_name]
 
@@ -687,15 +687,17 @@ def _wrap_snap_operations(
                 snap.ensure(state=state, classic=classic, channel=channel)
             snaps["success"].append(snap)
         except SnapError as e:
-            logger.warning(f"Failed to {op} snap {s}: {e.message}!")
+            logger.warning("Failed to {} snap {}: {}!".format(op, s, e.message))
             snaps["failed"].append(s)
         except SnapNotFoundError:
-            logger.warning(f"Snap '{s}' not found in cache!")
+            logger.warning("Snap '{}' not found in cache!".format(s))
             snaps["failed"].append(s)
 
     if len(snaps["failed"]):
         raise SnapError(
-            f"Failed to install or refresh snap(s): {', '.join([s for s in snaps['failed']])}"
+            "Failed to install or refresh snap(s): {}".format(
+                ", ".join([s for s in snaps["failed"]])
+            )
         )
 
     return snaps["success"] if len(snaps["success"]) > 1 else snaps["success"][0]

--- a/lib/charms/operator_libs_linux/v0/snap.py
+++ b/lib/charms/operator_libs_linux/v0/snap.py
@@ -81,7 +81,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 
 def _cache_init(func):

--- a/tests/integration/test_apt.py
+++ b/tests/integration/test_apt.py
@@ -20,7 +20,7 @@ def test_install_package():
     except apt.PackageNotFoundError:
         logger.error("A specified package not found in package cache or on system")
     except apt.PackageError as e:
-        logger.error(f"Could not install package. Reason: {e.message}")
+        logger.error("Could not install package. Reason: {}".format(e.message))
 
     assert get_command_path("zsh") == "/usr/bin/zsh"
     assert get_command_path("cfssl") == "/usr/bin/cfssl"

--- a/tests/integration/test_passwd.py
+++ b/tests/integration/test_passwd.py
@@ -17,8 +17,10 @@ def test_add_user():
 
     u = passwd.add_user(username="test-user-0")
 
-    expected_passwd_line = f"{u.pw_name}:x:{u.pw_uid}:{u.pw_gid}::{u.pw_dir}:{u.pw_shell}"
-    expected_group_line = f"{u.pw_name}:x:{u.pw_gid}:"
+    expected_passwd_line = "{}:x:{}:{}::{}:{}".format(
+        u.pw_name, u.pw_uid, u.pw_gid, u.pw_dir, u.pw_shell
+    )
+    expected_group_line = "{}:x:{}:".format(u.pw_name, u.pw_gid)
 
     assert passwd.user_exists("test-user-0") is not None
     assert expected_group_line in lines_in_file("/etc/group")
@@ -33,8 +35,10 @@ def test_remove_user():
 
     passwd.remove_user("test-user-0")
 
-    expected_passwd_line = f"{u.pw_name}:x:{u.pw_uid}:{u.pw_gid}::{u.pw_dir}:{u.pw_shell}"
-    expected_group_line = f"{u.pw_name}:x:{u.pw_gid}:"
+    expected_passwd_line = "{}:x:{}:{}::{}:{}".format(
+        u.pw_name, u.pw_uid, u.pw_gid, u.pw_dir, u.pw_shell
+    )
+    expected_group_line = "{}:x:{}:".format(u.pw_name, u.pw_gid)
 
     assert passwd.user_exists("test-user-0") is None
     assert expected_group_line not in lines_in_file("/etc/group")
@@ -43,7 +47,7 @@ def test_remove_user():
 
 def test_add_user_with_params():
     u = passwd.add_user(username="test-user-1", shell="/bin/bash", primary_group="admin")
-    expected = f"{u.pw_name}:x:{u.pw_uid}:{u.pw_gid}::{u.pw_dir}:{u.pw_shell}"
+    expected = "{}:x:{}:{}::{}:{}".format(u.pw_name, u.pw_uid, u.pw_gid, u.pw_dir, u.pw_shell)
 
     assert expected in lines_in_file("/etc/passwd")
 
@@ -55,7 +59,7 @@ def test_add_group():
 
     g = passwd.add_group(group_name="test-group")
 
-    expected = f"{g.gr_name}:x:{g.gr_gid}:"
+    expected = "{}:x:{}:".format(g.gr_name, g.gr_gid)
 
     assert passwd.group_exists("test-group") is not None
     assert expected in lines_in_file("/etc/group")
@@ -67,7 +71,7 @@ def test_remove_group():
     g = passwd.add_group(group_name="test-group")
     assert passwd.group_exists("test-group") is not None
 
-    expected = f"{g.gr_name}:x:{g.gr_gid}:"
+    expected = "{}:x:{}:".format(g.gr_name, g.gr_gid)
     assert expected in lines_in_file("/etc/group")
 
     passwd.remove_group("test-group")

--- a/tests/integration/test_snap.py
+++ b/tests/integration/test_snap.py
@@ -19,7 +19,7 @@ def test_snap_install():
         if not juju.present:
             juju.ensure(snap.SnapState.Latest, classic="True", channel="stable")
     except snap.SnapError as e:
-        logger.error(f"An exception occurred when installing Juju. Reason: {e.message}")
+        logger.error("An exception occurred when installing Juju. Reason: {}".format(e.message))
 
     assert get_command_path("juju") == "/snap/bin/juju"
 

--- a/tests/unit/fake_snapd.py
+++ b/tests/unit/fake_snapd.py
@@ -70,7 +70,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
     def internal_server_error(self, msg):
         d = {
             "result": {
-                "message": f"internal server error: {msg}",
+                "message": "internal server error: {}".format(msg),
             },
             "status": "Internal Server Error",
             "status-code": 500,

--- a/tests/unit/test_repo.py
+++ b/tests/unit/test_repo.py
@@ -76,13 +76,15 @@ class TestRepositoryMapping(TestCase):
 
         repo.disable()
         self.assertIn(
-            f"# {repo.repotype} {repo.uri} {repo.release} {' '.join(repo.groups)}\n",
+            "# {} {} {} {}\n".format(repo.repotype, repo.uri, repo.release, " ".join(repo.groups)),
             open(repo.filename).readlines(),
         )
 
         r.disable(other)
         self.assertIn(
-            f"# {other.repotype} [signed-by={other.gpg_key}] {other.uri} {other.release} {' '.join(other.groups)}\n",
+            "# {} [signed-by={}] {} {} {}\n".format(
+                other.repotype, other.gpg_key, other.uri, other.release, " ".join(other.groups)
+            ),
             open(other.filename).readlines(),
         )
 
@@ -98,7 +100,7 @@ class TestRepositoryMapping(TestCase):
         )
         r.add(d, default_filename=False)
         self.assertIn(
-            f"{d.repotype} {d.uri} {d.release} {' '.join(d.groups)}\n",
+            "{} {} {} {}\n".format(d.repotype, d.uri, d.release, " ".join(d.groups)),
             open(d.filename).readlines(),
         )
 

--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,7 @@ deps =
     pytest
     coverage[toml]
     -r{toxinidir}/requirements.txt
-    pyfakefs
+    pyfakefs==4.4.0
 commands =
 	coverage run --source={[vars]lib_dir} \
         -m pytest --ignore={[vars]tst_dir}integration -v --tb native {posargs}


### PR DESCRIPTION
This PR enables the support for Python 3.5 by introducing the following changes:

- Change f-strings (from Python 3.6+) to str.format().
- Change the pyfakefs to the latest version that supports Python 3.5.
- Add the same Python versions from OF CI to this repo CI. 
- Sort options dict in order to have a consistent order in Python 3.5.

Python 3.5 support is important in order to create charms like the new Postgres Machine Charm and continue to support Xenial (which uses Python 3.5).