### PR TITLE
remove warnings for missing snap cache data

### DIFF
--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -81,7 +81,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 0
+LIBPATCH = 1
 
 
 def _cache_init(func):


### PR DESCRIPTION
Snapd updates the `/var/cache/snapd/names` cache file infrequently and it
is normal for it to be not present.  Because this is a normal condition
of operation, the relevant warnings have been removed.

Fixes #34.