### PR TITLE
feat: add service management functionality to snap.py

### DIFF
--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -81,7 +81,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 
 def _cache_init(func):

--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -313,18 +313,19 @@ class Snap(object):
 
         self._snap_daemons("stop", services, options)
 
-    def logs(self, service: Optional[List[str]] = None, num_lines: Optional[int] = 10) -> str:
+    def logs(self, services: Optional[List[str]] = None, num_lines: Optional[int] = 10) -> str:
         """Shows a snap services' logs.
 
         Args:
-            services (list): (optional) list of individual snap services to show logs from (otherwise all)
+            services (list): (optional) list of individual snap services to show logs from
+                (otherwise all)
             num_lines (int): (optional) integer number of log lines to return. Default `10`
         """
         options = []
         if num_lines:
             options.append(f"-n={num_lines}")
 
-        return self._snap_daemons("logs", service, options).stdout
+        return self._snap_daemons("logs", services, options).stdout
 
     def restart(
         self, services: Optional[List[str]] = None, reload: Optional[bool] = False
@@ -332,8 +333,10 @@ class Snap(object):
         """Restarts a snap's services.
 
         Args:
-            services (list): (optional) list of individual snap services to show logs from (otherwise all)
-            reload (bool): (optional) flag to use the service reload command, if available. Default `False`
+            services (list): (optional) list of individual snap services to show logs from.
+                (otherwise all)
+            reload (bool): (optional) flag to use the service reload command, if available.
+                Default `False`
         """
         options = []
         if reload:
@@ -891,4 +894,4 @@ def install_local(
 
         return c[snap_name]
     except CalledProcessError as e:
-        raise SnapError("Could not install snap {}: {}".format(_cmd, filename, e.output))
+        raise SnapError("Could not install snap {}: {}".format(filename, e.output))

--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -107,7 +107,7 @@ class SnapService:
         enabled: bool = False,
         active: bool = False,
         activators: List[str] = [],
-        **kwargs,
+        **kwargs
     ):
         self.daemon = daemon
         self.daemon_scope = kwargs.get("daemon-scope", None) or daemon_scope

--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -107,7 +107,7 @@ class SnapService:
         enabled: bool = False,
         active: bool = False,
         activators: List[str] = [],
-        **kwargs
+        **kwargs,
     ):
         self.daemon = daemon
         self.daemon_scope = kwargs.get("daemon-scope", None) or daemon_scope

--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -286,7 +286,7 @@ class Snap(object):
 
         if services:
             # an attempt to keep the command constrained to the snap instance's services
-            services = [f"{self._name}.{service}" for service in services]
+            services = ["{}.{}".format(self._name, service) for service in services]
         else:
             services = [self._name]
 

--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -468,7 +468,7 @@ class Snap(object):
         try:
             self._apps = self._snap_client.get_installed_snap_apps(self._name)
         except SnapAPIError:
-            logger.warning("Unable to retrieve snap apps for {}".format(self._name))
+            logger.debug("Unable to retrieve snap apps for {}".format(self._name))
             self._apps = []
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ show_missing = true
 # Formatting tools configuration
 [tool.black]
 line-length = 99
-target-version = ["py38"]
+target-version = ["py35"]
 
 [tool.isort]
 profile = "black"

--- a/tests/integration/test_snap.py
+++ b/tests/integration/test_snap.py
@@ -107,7 +107,7 @@ def test_snap_start():
 
     assert kp.services
     kp.start()
-    assert kp.services["daemon"]["active"] == True
+    assert kp.services["daemon"]["active"] is not False
 
     with pytest.raises(snap.SnapError):
         kp.start(["foobar"])
@@ -119,8 +119,8 @@ def test_snap_stop():
     kp.ensure(snap.SnapState.Latest, classic=True, channel="latest/stable")
 
     kp.stop(["daemon"], disable=True)
-    assert kp.services["daemon"]["active"] == False
-    assert kp.services["daemon"]["enabled"] == False
+    assert kp.services["daemon"]["active"] is False
+    assert kp.services["daemon"]["enabled"] is False
 
 
 def test_snap_logs():

--- a/tests/integration/test_snap.py
+++ b/tests/integration/test_snap.py
@@ -7,6 +7,8 @@ import logging
 
 from charms.operator_libs_linux.v1 import snap
 from helpers import get_command_path
+import pytest
+
 
 logger = logging.getLogger(__name__)
 
@@ -96,3 +98,40 @@ def test_snap_ensure():
 def test_new_snap_ensure():
     vlc = snap.SnapCache()["vlc"]
     vlc.ensure(snap.SnapState.Latest, channel="edge")
+
+
+def test_snap_start():
+    cache = snap.SnapCache()
+    lxd = cache["lxd"]
+    lxd.ensure(snap.SnapState.Latest, channel="latest")
+
+    assert lxd.services
+    print(lxd.services)
+    lxd.start()
+    assert lxd.services["daemon"]["Current"] == "active"
+
+    with pytest.raises(snap.SnapError):
+        lxd.start(["foobar"])
+
+def test_snap_stop():
+    cache = snap.SnapCache()
+    lxd = cache["lxd"]
+    lxd.ensure(snap.SnapState.Latest, channel="latest")
+
+    lxd.stop(["daemon"], disable=True)
+    assert lxd.services["daemon"]["Current"] == "inactive"
+    assert lxd.services["daemon"]["Startup"] == "disabled"
+
+def test_snap_logs():
+    cache = snap.SnapCache()
+    lxd = cache["lxd"]
+    lxd.ensure(snap.SnapState.Latest, channel="latest")
+
+    assert len(lxd.logs(num_lines=10).splitlines()) == 10
+
+def test_snap_restart():
+    cache = snap.SnapCache()
+    lxd = cache["lxd"]
+    lxd.ensure(snap.SnapState.Latest, channel="latest")
+
+    lxd.restart()

--- a/tests/integration/test_snap.py
+++ b/tests/integration/test_snap.py
@@ -134,7 +134,7 @@ def test_snap_logs():
     kp.start()
     kp.stop()
 
-    assert len(kp.logs(num_lines=10).splitlines()) == 10
+    assert len(kp.logs(num_lines=15).splitlines()) == 15
 
 
 def test_snap_restart():

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -338,7 +338,7 @@ class TestSnapCache(unittest.TestCase):
                     "daemon": "simple",
                     "enabled": True,
                     "active": False,
-                    "daemon-scope": None,
+                    "daemon_scope": None,
                     "activators": [],
                 }
             },

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -313,19 +313,23 @@ class TestSnapCache(unittest.TestCase):
             capture_output=True,
         )
 
-    def test_apps_property(self):
+    @patch("charms.operator_libs_linux.v1.snap.SnapClient.get_installed_snap_apps")
+    def test_apps_property(self, patched):
         s = SnapCacheTester()
         s._snap_client.get_installed_snaps.return_value = json.loads(installed_result)["result"]
         s._load_installed_snaps()
 
+        patched.return_value = json.loads(installed_result)["result"][0]["apps"]
         self.assertEqual(len(s["charmcraft"].apps), 2)
         self.assertIn({"snap": "charmcraft", "name": "charmcraft"}, s["charmcraft"].apps)
 
-    def test_services_property(self):
+    @patch("charms.operator_libs_linux.v1.snap.SnapClient.get_installed_snap_apps")
+    def test_services_property(self, patched):
         s = SnapCacheTester()
         s._snap_client.get_installed_snaps.return_value = json.loads(installed_result)["result"]
         s._load_installed_snaps()
 
+        patched.return_value = json.loads(installed_result)["result"][0]["apps"]
         self.assertEqual(len(s["charmcraft"].services), 1)
         self.assertDictEqual(
             s["charmcraft"].services,


### PR DESCRIPTION
## Motivation
- Add daemon service management functionality within `snapctl` alongside a `Snap` instance, keeping it contained with the popular `Snap` instance for charming

## Main Changes
- feat: add `start`, `stop`, `logs`, `restart` methods to `Snap` object (matching `snapctl`)


    - Methods can take a `list`,`str` or None services, evaluating to `snap start lxd.activate lxd.user-daemon`, `snap start lxd.user-daemon` or `snap start lxd`
    - These are called by `Snap._snap_daemons()` which (attempts) to ensure that a given snap instance can only launch services containing it's own `_name`
- feat: add `Snap.services`, `Snap.apps` properties to get metadata from the API for installed snaps


    - `Snap.apps` looks like `{"snap":"charmcraft","name":"charmcraft"},{"snap":"juju","name":"fetch-oci","daemon":"oneshot","daemon-scope":"system","enabled":true}`, which could be useful for a user to know what commands are facilitated by the installed snap
    - `Snap.services` looks like below. I felt it gave a useful format for accessing snap daemons by key, with the `snap` field removed due to it being redundant for a named `Snap` instance, and filling information missing from the API (i.e `active` would not exist in the API response if not active)
      ```
      {
        "fetch-oci": {
          "daemon": "oneshot",
          "daemon-scope": "system",
          "enabled": False,
          "active": False,
          "activators": [],
        },
      }
      ```

## Minor Changes
- style: set API request return type to `Any`, because JSON is JSON
- style: minor formatting changes
- fix: update some old `str.format` usages that I don't think worked before