### PR TITLE
Adds ability to hold snap refreshes system wide

### DIFF
--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -82,7 +82,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 
 def _cache_init(func):

--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -936,8 +936,8 @@ def hold_refresh(days: int = 90) -> bool:
         days: number of days to hold system refreshes for. Maximum 90. Set to zero to remove hold.
     """
     # Currently the snap daemon can only hold for a maximum of 90 days
-    if days > 90:
-        raise ValueError("days must be between 1 and 90")
+    if not isinstance(days, int) or days > 90:
+        raise ValueError("days must be an int between 1 and 90")
     elif days == 0:
         _system_set("refresh.hold", "")
         logger.info("Removed system-wide snap refresh hold")

--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -67,6 +67,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from collections.abc import Mapping
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from subprocess import CalledProcessError, CompletedProcess
 from typing import Any, Dict, Iterable, List, Optional, Union
@@ -912,3 +913,41 @@ def install_local(
         return c[snap_name]
     except CalledProcessError as e:
         raise SnapError("Could not install snap {}: {}".format(filename, e.output))
+
+
+def _system_set(config_item: str, value: str) -> None:
+    """Helper for setting snap system config values.
+
+    Args:
+        config_item: name of snap system setting. E.g. 'refresh.hold'
+        value: value to assign
+    """
+    _cmd = ["snap", "set", "system", "{}={}".format(config_item, value)]
+    try:
+        subprocess.check_call(_cmd, universal_newlines=True)
+    except CalledProcessError:
+        raise SnapError("Failed setting system config '{}' to '{}'".format(config_item, value))
+
+
+def hold_refresh(days: int = 90) -> bool:
+    """Set the system-wide snap refresh hold.
+
+    Args:
+        days: number of days to hold system refreshes for. Maximum 90. Set to zero to remove hold.
+    """
+    # Currently the snap daemon can only hold for a maximum of 90 days
+    if days > 90:
+        raise ValueError("days must be between 1 and 90")
+    elif days == 0:
+        _system_set("refresh.hold", "")
+        logger.info("Removed system-wide snap refresh hold")
+    else:
+        # Add the number of days to current time
+        target_date = datetime.now(timezone.utc).astimezone() + timedelta(days=days)
+        # Format for the correct datetime format
+        hold_date = target_date.strftime("%Y-%m-%dT%H:%M:%S%z")
+        # Python dumps the offset in format '+0100', we need '+01:00'
+        hold_date = "{0}:{1}".format(hold_date[:-2], hold_date[-2:])
+        # Actually set the hold date
+        _system_set("refresh.hold", hold_date)
+        logger.info("Set system-wide snap refresh hold to: %s", hold_date)

--- a/tests/integration/test_snap.py
+++ b/tests/integration/test_snap.py
@@ -4,7 +4,8 @@
 
 
 import logging
-from subprocess import CalledProcessError
+from datetime import datetime, timedelta
+from subprocess import CalledProcessError, check_output
 
 import pytest
 from charms.operator_libs_linux.v1 import snap
@@ -146,3 +147,17 @@ def test_snap_restart():
         kp.restart()
     except CalledProcessError as e:
         pytest.fail(e.stderr)
+
+
+def test_hold_refresh():
+    hold_date = (datetime.now() + timedelta(days=90)).strftime("%Y-%m-%d")
+    snap.hold_refresh()
+    result = check_output(["snap", "refresh", "--time"])
+    assert f"hold: {hold_date}" in result.decode()
+
+
+def test_reset_hold_refresh():
+    snap.hold_refresh()
+    snap.hold_refresh(0)
+    result = check_output(["snap", "refresh", "--time"])
+    assert "hold: " not in result.decode()

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -495,11 +495,17 @@ class TestSnapBareMethods(unittest.TestCase):
         except snap.SnapError as e:
             self.assertEqual(str(e), "Failed setting system config 'refresh.hold' to 'foobar'")
 
-    def test_hold_refresh_invalid(self):
+    def test_hold_refresh_invalid_too_high(self):
         try:
             snap.hold_refresh(days=120)
         except ValueError as e:
-            self.assertEqual(str(e), "days must be between 1 and 90")
+            self.assertEqual(str(e), "days must be an int between 1 and 90")
+
+    def test_hold_refresh_invalid_non_int(self):
+        try:
+            snap.hold_refresh(days="foobar")
+        except ValueError as e:
+            self.assertEqual(str(e), "days must be an int between 1 and 90")
 
     @patch("charms.operator_libs_linux.v1.snap.subprocess.check_call")
     def test_hold_refresh_reset(self, mock_subprocess):

--- a/tox.ini
+++ b/tox.ini
@@ -62,6 +62,7 @@ deps =
     coverage[toml]
     -r{toxinidir}/requirements.txt
     pyfakefs==4.4.0
+    freezegun
 commands =
 	coverage run --source={[vars]lib_dir} \
         -m pytest --ignore={[vars]tst_dir}integration -v --tb native {posargs}


### PR DESCRIPTION
The feature to hold an individual snap is not yet in snapd, but this allows a charm author to hold snap refreshes system-wide