### PR TITLE
snap: remove empty args from check_output

### DIFF
--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -82,7 +82,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 
 def _cache_init(func):
@@ -885,7 +885,7 @@ def _wrap_snap_operations(
 
 
 def install_local(
-    self, filename: str, classic: Optional[bool] = False, dangerous: Optional[bool] = False
+    filename: str, classic: Optional[bool] = False, dangerous: Optional[bool] = False
 ) -> Snap:
     """Perform a snap operation.
 
@@ -901,9 +901,11 @@ def install_local(
         "snap",
         "install",
         filename,
-        "--classic" if classic else "",
-        "--dangerous" if dangerous else "",
     ]
+    if classic:
+        _cmd.append("--classic")
+    if dangerous:
+        _cmd.append("--dangerous")
     try:
         result = subprocess.check_output(_cmd, universal_newlines=True).splitlines()[0]
         snap_name, _ = result.split(" ", 1)

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -523,3 +523,27 @@ class TestSnapBareMethods(unittest.TestCase):
             ["snap", "set", "system", "refresh.hold=1970-04-01T00:00:00+00:00"],
             universal_newlines=True,
         )
+
+    @patch("charms.operator_libs_linux.v1.snap.subprocess.check_output")
+    def test_install_local(self, mock_subprocess):
+        mock_subprocess.return_value = "curl XXX installed"
+        snap.install_local("./curl.snap")
+        mock_subprocess.assert_called_with(
+            ["snap", "install", "./curl.snap"],
+            universal_newlines=True,
+        )
+
+    @patch("charms.operator_libs_linux.v1.snap.subprocess.check_output")
+    def test_install_local_args(self, mock_subprocess):
+        mock_subprocess.return_value = "curl XXX installed"
+        for kwargs, cmd_args in [
+            ({"classic": True}, ["--classic"]),
+            ({"dangerous": True}, ["--dangerous"]),
+            ({"classic": True, "dangerous": True}, ["--classic", "--dangerous"]),
+        ]:
+            snap.install_local("./curl.snap", **kwargs)
+            mock_subprocess.assert_called_with(
+                ["snap", "install", "./curl.snap"] + cmd_args,
+                universal_newlines=True,
+            )
+            mock_subprocess.reset_mock()


### PR DESCRIPTION
There were two issues with the module level function install_local() that needed adressing.

- The unused function parameter: `self`
- Some combinations of the function parameters `classic` and `dangerous` ended up in passing empty arguments to the `snap` process when called with subprocess.check_output(), which it did not really like.

Fixes: #49
Signed-off-by: Mert Kırpıcı <mert.kirpici@canonical.com>