### PR TITLE
passwd: create home dir for system users

### DIFF
--- a/lib/charms/operator_libs_linux/v0/passwd.py
+++ b/lib/charms/operator_libs_linux/v0/passwd.py
@@ -99,6 +99,7 @@ def add_user(
     secondary_groups: List[str] = None,
     uid: int = None,
     home_dir: str = None,
+    create_home: bool = True,
 ) -> str:
     """Add a user to the system.
 
@@ -113,6 +114,7 @@ def add_user(
         secondary_groups: Optional list of additional groups
         uid: UID for user being created
         home_dir: Home directory for user
+        create_home: Force home directory creation
 
     Returns:
         The password database entry struct, as returned by `pwd.getpwnam`
@@ -135,7 +137,9 @@ def add_user(
     if home_dir:
         cmd.extend(["--home", str(home_dir)])
     if password:
-        cmd.extend(["--password", password, "--create-home"])
+        cmd.extend(["--password", password])
+    if create_home:
+        cmd.append("--create-home")
     if system_user or password is None:
         cmd.append("--system")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ profile = "black"
 [tool.flake8]
 max-line-length = 99
 max-doc-length = 99
-max-complexity = 13
+max-complexity = 14
 exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
 select = ["E", "W", "F", "C", "N", "R", "D", "H"]
 # Ignore W503, E501 because using black creates errors with this

--- a/tests/unit/test_passwd.py
+++ b/tests/unit/test_passwd.py
@@ -170,7 +170,7 @@ class TestPasswd(TestCase):
 
         self.assertEqual(result, new_user_pwnam)
         check_output.assert_called_with(
-            ["useradd", "--shell", "/bin/bash", "--system", username], stderr=-2
+            ["useradd", "--shell", "/bin/bash", "--create-home", "--system", username], stderr=-2
         )
         getpwnam.assert_called_with(username)
 
@@ -193,6 +193,7 @@ class TestPasswd(TestCase):
                 "/bin/bash",
                 "--home",
                 "/var/lib/johndoe",
+                "--create-home",
                 "--system",
                 username,
             ],
@@ -218,6 +219,7 @@ class TestPasswd(TestCase):
                 "/bin/bash",
                 "--uid",
                 str(user_id),
+                "--create-home",
                 "--system",
                 "-g",
                 user_name,


### PR DESCRIPTION
The `--system` argument needs also `--create-home` argument to be present for the creation of home directory for system users.

This change adds a new parameter to the `add_user` function signature, called `create_home` which defaults to True to provide backwards compatibility with the current api. After this change, home directory will be always created regardless of regular users or system users unless False is passed for `create_home`.