### PR TITLE
Fix snap charmlib's `install_local` method

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on: [pull_request, push]
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -14,10 +14,10 @@ jobs:
         run: tox -e lint
   unit-test:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.5", "3.6", "3.7", "3.8", "3.9"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -31,7 +31,7 @@ jobs:
         run: tox -e unit
   integration-test:
     name: Integration tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install dependencies
         run: python3 -m pip install tox
       - name: Run linters
@@ -20,9 +20,9 @@ jobs:
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -34,10 +34,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: whywaita/setup-lxd@v1
-        with:
-          lxd_version: latest/stable
+        uses: actions/checkout@v3
+      - uses: canonical/setup-lxd@90d76101915da56a42a562ba766b1a77019242fd
       - name: Install dependencies
         run: python -m pip install tox
       - name: Run integration tests

--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -83,7 +83,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 
 # Regex to locate 7-bit C1 ANSI sequences

--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -60,6 +60,7 @@ import http.client
 import json
 import logging
 import os
+import re
 import socket
 import subprocess
 import sys
@@ -907,8 +908,10 @@ def install_local(
     if dangerous:
         _cmd.append("--dangerous")
     try:
-        result = subprocess.check_output(_cmd, universal_newlines=True).splitlines()[0]
+        ansi_filter = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+        result = subprocess.check_output(_cmd, universal_newlines=True).splitlines()[-1]
         snap_name, _ = result.split(" ", 1)
+        snap_name = ansi_filter.sub("", snap_name)
 
         c = SnapCache()
 

--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -86,6 +86,10 @@ LIBAPI = 1
 LIBPATCH = 5
 
 
+# Regex to locate 7-bit C1 ANSI sequences
+ansi_filter = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+
+
 def _cache_init(func):
     def inner(*args, **kwargs):
         if _Cache.cache is None:
@@ -908,14 +912,19 @@ def install_local(
     if dangerous:
         _cmd.append("--dangerous")
     try:
-        ansi_filter = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
         result = subprocess.check_output(_cmd, universal_newlines=True).splitlines()[-1]
         snap_name, _ = result.split(" ", 1)
         snap_name = ansi_filter.sub("", snap_name)
 
         c = SnapCache()
 
-        return c[snap_name]
+        try:
+            return c[snap_name]
+        except SnapAPIError as e:
+            logger.error(
+                "Could not find snap {} when querying Snapd socket: {}".format(snap_name, e.body)
+            )
+            raise SnapError("Failed to find snap {} in Snap cache".format(snap_name))
     except CalledProcessError as e:
         raise SnapError("Could not install snap {}: {}".format(filename, e.output))
 

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -525,9 +525,11 @@ class TestSnapBareMethods(unittest.TestCase):
         )
 
     def test_ansi_filter(self):
-        assert snap.ansi_filter.sub('', '\x1b[0m\x1b[?25h\x1b[Khello-world-gtk') == "hello-world-gtk"
-        assert snap.ansi_filter.sub('', '\x1b[0m\x1b[?25h\x1b[Kpypi-server') == "pypi-server"
-        assert snap.ansi_filter.sub('', '\x1b[0m\x1b[?25h\x1b[Kparca') == "parca"
+        assert (
+            snap.ansi_filter.sub("", "\x1b[0m\x1b[?25h\x1b[Khello-world-gtk") == "hello-world-gtk"
+        )
+        assert snap.ansi_filter.sub("", "\x1b[0m\x1b[?25h\x1b[Kpypi-server") == "pypi-server"
+        assert snap.ansi_filter.sub("", "\x1b[0m\x1b[?25h\x1b[Kparca") == "parca"
 
     @patch("charms.operator_libs_linux.v1.snap.subprocess.check_output")
     def test_install_local(self, mock_subprocess):

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -524,6 +524,11 @@ class TestSnapBareMethods(unittest.TestCase):
             universal_newlines=True,
         )
 
+    def test_ansi_filter(self):
+        assert snap.ansi_filter.sub('', '\x1b[0m\x1b[?25h\x1b[Khello-world-gtk') == "hello-world-gtk"
+        assert snap.ansi_filter.sub('', '\x1b[0m\x1b[?25h\x1b[Kpypi-server') == "pypi-server"
+        assert snap.ansi_filter.sub('', '\x1b[0m\x1b[?25h\x1b[Kparca') == "parca"
+
     @patch("charms.operator_libs_linux.v1.snap.subprocess.check_output")
     def test_install_local(self, mock_subprocess):
         mock_subprocess.return_value = "curl XXX installed"

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8==4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins


### PR DESCRIPTION
Pull request contains fixes for the snap charm library's `install_local` method. Here is what I changed:

1. On `subprocess.check_output(...).splitlines()`, I changed the selected index from 0 to -1.
2. I added a regular expression that filters ANSI characters out from the captured `snap_name` so that the API request to the snapd socket does not fail.

Closes: #54, #55