### PR TITLE
fix: inherit environment before adding new keys

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.5", "3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.10"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/lib/charms/operator_libs_linux/v0/apt.py
+++ b/lib/charms/operator_libs_linux/v0/apt.py
@@ -124,7 +124,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 9
 
 
 VALID_SOURCE_TYPES = ("deb", "deb-src")

--- a/lib/charms/operator_libs_linux/v0/apt.py
+++ b/lib/charms/operator_libs_linux/v0/apt.py
@@ -250,7 +250,8 @@ class DebianPackage:
             package_names = [package_names]
         _cmd = ["apt-get", "-y", *optargs, command, *package_names]
         try:
-            env = {"DEBIAN_FRONTEND": "noninteractive"}
+            env = os.environ.copy()
+            env["DEBIAN_FRONTEND"] = "noninteractive"
             check_call(_cmd, env=env, stderr=PIPE, stdout=PIPE)
         except CalledProcessError as e:
             raise PackageError(

--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,6 @@ deps =
     coverage[toml]
     -r{toxinidir}/requirements.txt
     pyfakefs==4.4.0
-    freezegun
 commands =
 	coverage run --source={[vars]lib_dir} \
         -m pytest --ignore={[vars]tst_dir}integration -v --tb native {posargs}


### PR DESCRIPTION
# Current behaviour (per #60):

## Xenial
```bash
lxc launch ubuntu:xenial xenial
lxc exec xenial wget https://raw.githubusercontent.com/canonical/operator-libs-linux/main/lib/charms/operator_libs_linux/v0/apt.py
lxc exec xenial python3
```
```python
import apt
apt.update()
apt.add_package(['python3-pymongo'])
<...>
apt.PackageError: Could not install package(s) [['python3-pymongo=3.2-1build1']]: None
```
❌

## Bionic
```bash
lxc launch ubuntu:bionic bionic
lxc exec bionic wget https://raw.githubusercontent.com/canonical/operator-libs-linux/main/lib/charms/operator_libs_linux/v0/apt.py
lxc exec bionic python3
```
```python
import apt
apt.update()
apt.add_package(['python3-pymongo'])
<...>
apt.PackageError: Could not install package(s) [['python3-pymongo=3.6.1+dfsg1-1']]: None
```
❌

## Focal
```bash
lxc launch ubuntu:focal focal
lxc exec focal wget https://raw.githubusercontent.com/canonical/operator-libs-linux/main/lib/charms/operator_libs_linux/v0/apt.py
lxc exec focal python3
```
```python
import apt
apt.update()
apt.add_package(['python3-pymongo'])
<apt.DebianPackage: {'_name': 'python3-pymongo', '_arch': 'amd64', '_state': <PackageState.Present: 'present'>, '_version': <apt.Version: {'_version': '3.10.1-0ubuntu2', '_epoch': ''}>}>
```
✔️

## Jammy
```bash
lxc launch ubuntu:jammy jammy
lxc exec jammy wget https://raw.githubusercontent.com/canonical/operator-libs-linux/main/lib/charms/operator_libs_linux/v0/apt.py
lxc exec jammy python3
```
```python
import apt
apt.update()
apt.add_package(['python3-pymongo'])
<apt.DebianPackage: {'_name': 'python3-pymongo', '_arch': 'amd64', '_state': <PackageState.Present: 'present'>, '_version': <apt.Version: {'_version': '3.11.0-1build4', '_epoch': ''}>}>
```
✔️
# Post-change behaviour

## Xenial
```bash
lxc exec xenial -- rm apt.py
lxc exec xenial wget https://raw.githubusercontent.com/jsimpso/operator-libs-linux/main/lib/charms/operator_libs_linux/v0/apt.py
lxc exec xenial python3
```
```python
import apt
apt.update()
apt.add_package(['python3-pymongo'])
<apt.DebianPackage: {'_arch': 'amd64', '_state': <PackageState.Present: 'present'>, '_name': 'python3-pymongo', '_version': <apt.Version: {'_version': '3.2-1build1', '_epoch': ''}>}>
```
✔️

## Bionic
```bash
lxc exec bionic -- rm apt.py
lxc exec bionic wget https://raw.githubusercontent.com/jsimpso/operator-libs-linux/main/lib/charms/operator_libs_linux/v0/apt.py
lxc exec bionic python3
```
```python
import apt
apt.update()
apt.add_package(['python3-pymongo'])
<apt.DebianPackage: {'_name': 'python3-pymongo', '_arch': 'amd64', '_state': <PackageState.Present: 'present'>, '_version': <apt.Version: {'_version': '3.6.1+dfsg1-1', '_epoch': ''}>}>
```
✔️

## Focal
```bash
lxc exec focal -- rm apt.py
lxc exec focal wget https://raw.githubusercontent.com/jsimpso/operator-libs-linux/main/lib/charms/operator_libs_linux/v0/apt.py
lxc exec focal -- apt remove python3-pymongo -y
lxc exec focal python3
```
```python
import apt
apt.update()
apt.add_package(['python3-pymongo'])
<apt.DebianPackage: {'_name': 'python3-pymongo', '_arch': 'amd64', '_state': <PackageState.Present: 'present'>, '_version': <apt.Version: {'_version': '3.10.1-0ubuntu2', '_epoch': ''}>}>
```
✔️

## Jammy
```bash
lxc exec jammy -- rm apt.py
lxc exec jammy wget https://raw.githubusercontent.com/jsimpso/operator-libs-linux/main/lib/charms/operator_libs_linux/v0/apt.py
lxc exec jammy -- apt remove python3-pymongo -y
lxc exec jammy python3
```
```python
import apt
apt.update()
apt.add_package(['python3-pymongo'])
<apt.DebianPackage: {'_name': 'python3-pymongo', '_arch': 'amd64', '_state': <PackageState.Present: 'present'>, '_version': <apt.Version: {'_version': '3.11.0-1build4', '_epoch': ''}>}>
```
✔️