### PR TITLE
Fix test-app issue due to binary Hashicorp GPG key

### DIFF
--- a/tests/integration/test_apt.py
+++ b/tests/integration/test_apt.py
@@ -47,8 +47,10 @@ def test_install_package_external_repository():
     with tempfile.NamedTemporaryFile() as key_file:
         urlretrieve("https://apt.releases.hashicorp.com/gpg", filename=key_file.name)
         process = subprocess.run(
-            ['gpg', '--keyring', key_file.name, '--no-default-keyring', '--export', '-a'],
-            stdout=subprocess.PIPE, encoding='utf-8')
+            ["gpg", "--keyring", key_file.name, "--no-default-keyring", "--export", "-a"],
+            stdout=subprocess.PIPE,
+            encoding="utf-8",
+        )
         key = process.stdout
 
     # Add the hashicorp repository if it doesn't already exist


### PR DESCRIPTION
Not sure how this ever worked -- maybe the Hashicorp URL used to return an ASCII key? Now it definitely returns binary, so use the gpg command to convert it to ASCII format.

```
___________________ test_install_package_external_repository ___________________
Traceback (most recent call last):
  File "/ops-libs-test/tests/integration/test_apt.py", line 45, in test_install_package_external_repository
    key = urlopen("https://apt.releases.hashicorp.com/gpg").read().decode()
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x99 in position 0: invalid start byte
```