### PR TITLE
fix: make placeholder charm a machine charm

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -5,11 +5,7 @@ type: charm
 bases:
   - build-on:
       - name: "ubuntu"
-        channel: "20.04"
+        channel: "22.04"
     run-on:
       - name: "ubuntu"
-        channel: "20.04"
-parts:
-  charm:
-    build-packages:
-      - git
+        channel: "22.04"

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -6,10 +6,3 @@ description: |
   Operator Framework team for use when authoring 'machine charms' that need
   to manipulate packages, users, services, etc.
 summary: Collection of Charm Libraries for authoring machine charms.
-containers:
-  placeholder:
-    resource: placeholder-image
-resources:
-  placeholder-image:
-    type: oci-image
-    description: OCI image for placeholder

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
-git+https://github.com/canonical/operator/#egg=ops
+ops


### PR DESCRIPTION
These are machine-charm utilities, so make the placeholder charm a machine charm so it shows up correctly in Charmhub. Do this by removing containers / resources from metadata.yaml.

Also:

- Update Ubuntu version to 22.04 (not that it matters for charm libs)
- Don't need to be on the latest master "ops", just use latest release

Fixes #47