### PR TITLE
Make import_key a stand-alone function for use with a DebianRepository

### DIFF
--- a/lib/charms/operator_libs_linux/v0/apt.py
+++ b/lib/charms/operator_libs_linux/v0/apt.py
@@ -896,7 +896,7 @@ def import_key(key: str) -> str:
         # write the key in GPG format so that apt-key list shows it
         key_gpg = DebianRepository._dearmor_gpg_key(key_asc.encode("utf-8"))
         gpg_key_filename = "/etc/apt/trusted.gpg.d/{}.gpg".format(key)
-        DebianRepository._write_apt_gpg_keyfile(key_name=key, key_material=key_gpg)
+        DebianRepository._write_apt_gpg_keyfile(key_name=gpg_key_filename, key_material=key_gpg)
         return gpg_key_filename
 
 

--- a/lib/charms/operator_libs_linux/v0/apt.py
+++ b/lib/charms/operator_libs_linux/v0/apt.py
@@ -841,6 +841,65 @@ def update() -> None:
     check_call(["apt-get", "update"], stderr=PIPE, stdout=PIPE)
 
 
+def import_key(key: str) -> str:
+    """Import an ASCII Armor key.
+
+    A Radix64 format keyid is also supported for backwards
+    compatibility. In this case Ubuntu keyserver will be
+    queried for a key via HTTPS by its keyid. This method
+    is less preferable because https proxy servers may
+    require traffic decryption which is equivalent to a
+    man-in-the-middle attack (a proxy server impersonates
+    keyserver TLS certificates and has to be explicitly
+    trusted by the system).
+
+    Args:
+        key: A GPG key in ASCII armor format,
+                    including BEGIN and END markers or a keyid.
+
+    Raises:
+        GPGKeyError if the key could not be imported
+    """
+    key = key.strip()
+    if "-" in key or "\n" in key:
+        # Send everything not obviously a keyid to GPG to import, as
+        # we trust its validation better than our own. eg. handling
+        # comments before the key.
+        logger.debug("PGP key found (looks like ASCII Armor format)")
+        if (
+            "-----BEGIN PGP PUBLIC KEY BLOCK-----" in key
+            and "-----END PGP PUBLIC KEY BLOCK-----" in key
+        ):
+            logger.debug("Writing provided PGP key in the binary format")
+            key_bytes = key.encode("utf-8")
+            key_name = DebianRepository._get_keyid_by_gpg_key(key_bytes)
+            key_gpg = DebianRepository._dearmor_gpg_key(key_bytes)
+            gpg_key_filename = "/etc/apt/trusted.gpg.d/{}.gpg".format(key_name)
+            DebianRepository._write_apt_gpg_keyfile(
+                key_name=gpg_key_filename, key_material=key_gpg
+            )
+            return gpg_key_filename
+        else:
+            raise GPGKeyError("ASCII armor markers missing from GPG key")
+    else:
+        logger.warning(
+            "PGP key found (looks like Radix64 format). "
+            "SECURELY importing PGP key from keyserver; "
+            "full key not provided."
+        )
+        # as of bionic add-apt-repository uses curl with an HTTPS keyserver URL
+        # to retrieve GPG keys. `apt-key adv` command is deprecated as is
+        # apt-key in general as noted in its manpage. See lp:1433761 for more
+        # history. Instead, /etc/apt/trusted.gpg.d is used directly to drop
+        # gpg
+        key_asc = DebianRepository._get_key_by_keyid(key)
+        # write the key in GPG format so that apt-key list shows it
+        key_gpg = DebianRepository._dearmor_gpg_key(key_asc.encode("utf-8"))
+        gpg_key_filename = "/etc/apt/trusted.gpg.d/{}.gpg".format(key)
+        DebianRepository._write_apt_gpg_keyfile(key_name=key, key_material=key_gpg)
+        return gpg_key_filename
+
+
 class InvalidSourceError(Error):
     """Exceptions for invalid source entries."""
 
@@ -1020,40 +1079,7 @@ class DebianRepository:
         Raises:
           GPGKeyError if the key could not be imported
         """
-        key = key.strip()
-        if "-" in key or "\n" in key:
-            # Send everything not obviously a keyid to GPG to import, as
-            # we trust its validation better than our own. eg. handling
-            # comments before the key.
-            logger.debug("PGP key found (looks like ASCII Armor format)")
-            if (
-                "-----BEGIN PGP PUBLIC KEY BLOCK-----" in key
-                and "-----END PGP PUBLIC KEY BLOCK-----" in key
-            ):
-                logger.debug("Writing provided PGP key in the binary format")
-                key_bytes = key.encode("utf-8")
-                key_name = self._get_keyid_by_gpg_key(key_bytes)
-                key_gpg = self._dearmor_gpg_key(key_bytes)
-                self._gpg_key_filename = "/etc/apt/trusted.gpg.d/{}.gpg".format(key_name)
-                self._write_apt_gpg_keyfile(key_name=self._gpg_key_filename, key_material=key_gpg)
-            else:
-                raise GPGKeyError("ASCII armor markers missing from GPG key")
-        else:
-            logger.warning(
-                "PGP key found (looks like Radix64 format). "
-                "SECURELY importing PGP key from keyserver; "
-                "full key not provided."
-            )
-            # as of bionic add-apt-repository uses curl with an HTTPS keyserver URL
-            # to retrieve GPG keys. `apt-key adv` command is deprecated as is
-            # apt-key in general as noted in its manpage. See lp:1433761 for more
-            # history. Instead, /etc/apt/trusted.gpg.d is used directly to drop
-            # gpg
-            key_asc = self._get_key_by_keyid(key)
-            # write the key in GPG format so that apt-key list shows it
-            key_gpg = self._dearmor_gpg_key(key_asc.encode("utf-8"))
-            self._gpg_key_filename = "/etc/apt/trusted.gpg.d/{}.gpg".format(key)
-            self._write_apt_gpg_keyfile(key_name=key, key_material=key_gpg)
+        self._gpg_key_filename = import_key(key)
 
     @staticmethod
     def _get_keyid_by_gpg_key(key_material: bytes) -> str:

--- a/lib/charms/operator_libs_linux/v0/apt.py
+++ b/lib/charms/operator_libs_linux/v0/apt.py
@@ -124,7 +124,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 9
+LIBPATCH = 10
 
 
 VALID_SOURCE_TYPES = ("deb", "deb-src")
@@ -854,8 +854,11 @@ def import_key(key: str) -> str:
     trusted by the system).
 
     Args:
-        key: A GPG key in ASCII armor format,
-                    including BEGIN and END markers or a keyid.
+        key: A GPG key in ASCII armor format, including BEGIN
+            and END markers or a keyid.
+
+    Returns:
+        The GPG key filename written.
 
     Raises:
         GPGKeyError if the key could not be imported

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -427,7 +427,6 @@ class TestSnapBareMethods(unittest.TestCase):
 
     @patch("charms.operator_libs_linux.v1.snap.subprocess")
     def test_cohort(self, mock_subprocess):
-
         mock_subprocess.check_output = MagicMock()
 
         snap.add("curl", channel="latest", cohort="+")
@@ -484,7 +483,6 @@ class TestSnapBareMethods(unittest.TestCase):
 
     @patch("charms.operator_libs_linux.v1.snap.subprocess.check_output")
     def test_snap_set(self, mock_subprocess):
-
         foo = snap.Snap("foo", snap.SnapState.Present, "stable", "1", "classic")
 
         foo.set({"bar": "baz"})

--- a/tests/unit/test_systemd.py
+++ b/tests/unit/test_systemd.py
@@ -168,7 +168,6 @@ class TestSystemD(unittest.TestCase):
 
     @with_mock_subp
     def test_service_resume(self, make_mock):
-
         # Service is already running
         mockp, kw = make_mock([0, 0, 0])
         resumed = systemd.service_resume("mysql")


### PR DESCRIPTION
This PR allows users to import a key without a dummy `DebianRepository` instance, by adding a top-level `import_key` function that does the work, and then refactoring `DebianRepository.import_key` to use this. Users that want to import a key but don't have a `DebianRepository` can just call the new top-level function.