### PR TITLE
Bump LIBPATCH for two libraries that had been modified but not bumped

### DIFF
--- a/lib/charms/operator_libs_linux/v0/passwd.py
+++ b/lib/charms/operator_libs_linux/v0/passwd.py
@@ -45,7 +45,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 
 def user_exists(user: Union[str, int]) -> Optional[pwd.struct_passwd]:

--- a/lib/charms/operator_libs_linux/v1/systemd.py
+++ b/lib/charms/operator_libs_linux/v1/systemd.py
@@ -60,7 +60,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 0
+LIBPATCH = 1
 
 
 class SystemdError(Exception):


### PR DESCRIPTION
These had been modified (systemd only with comment changes, but still) in previous PRs but LIBPATCH hadn't been bumped, so `charmhub publish-lib` was complaining that the content was different.