### PR TITLE
feat: add dnf charm library

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,3 +42,5 @@ jobs:
         run: python -m pip install tox
       - name: Run integration tests
         run: tox -e integration
+      - name: Run integration tests - cleantest
+        run: tox -e integration-but-with-cleantest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,5 +42,3 @@ jobs:
         run: python -m pip install tox
       - name: Run integration tests
         run: tox -e integration
-      - name: Run integration tests - cleantest
-        run: tox -e integration-cleantest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: canonical/setup-lxd@90d76101915da56a42a562ba766b1a77019242fd
+      - uses: canonical/setup-lxd@v0.1.0
+        with:
+          channel: 5.9/stable
       - name: Install dependencies
         run: python -m pip install tox
       - name: Run integration tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,4 +43,4 @@ jobs:
       - name: Run integration tests
         run: tox -e integration
       - name: Run integration tests - cleantest
-        run: tox -e integration-but-with-cleantest
+        run: tox -e integration-cleantest

--- a/lib/charms/operator_libs_linux/v0/dnf.py
+++ b/lib/charms/operator_libs_linux/v0/dnf.py
@@ -15,448 +15,225 @@
 
 """Abstractions for system's DNF package information and repositories."""
 
-import copy
-import itertools
 import os
+import re
 import shutil
 import subprocess
-from collections import deque
-from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
-from functools import wraps
 from io import StringIO
-from typing import Callable, Dict, List, Literal, Optional, Union
+from typing import Dict, Optional, Union
+
+
+class ExecutionError(Exception):
+    """Raise when dnf encounters an execution error."""
 
 
 class _PackageState(Enum):
     INSTALLED = "installed"
     AVAILABLE = "available"
     ABSENT = "absent"
-
-
-class DNFExecutionError(Exception):
-    """Raise when dnf encounters an execution error."""
-
-
-def _dnf(
-    command: str,
-    args: Optional[Union[Union[str, os.PathLike], List[Union[str, os.PathLike]]]] = None,
-    preargs: Optional[List[str]] = None,
-    postargs: Optional[List[str]] = None,
-) -> subprocess.CompletedProcess[str]:
-    """Execute DNF command.
-
-    Args:
-        command (str): Command to execute.
-        args (Optional[Union[Union[str, os.PathLike], List[Union[str, os.PathLike]]]]):
-            Arguments to operate on. (Default: None).
-        preargs (Optional[List[str]], optional):
-            Optional arguments to prepend before command. (Default: None).
-        postargs (Optional[List[str]], optional):
-            Optional arguments to append after command. (Default: None).
-
-    Raises:
-        DNFExecutionError: Raised if specified DNF command fails to execute.
-
-    Returns:
-        (subprocess.CompletedProcess[str]):
-            returncode, stdout, and stderr of completed DNF command.
-    """
-    args = [args] if type(args) == str else args if type(args) == list else []
-    preargs = preargs if preargs is not None else []
-    postargs = postargs if postargs is not None else []
-    cmd = ["dnf", "-y", *preargs, command, *postargs, *args]
-    try:
-        return subprocess.run(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            universal_newlines=True,
-        )
-    except subprocess.CalledProcessError as e:
-        raise DNFExecutionError(
-            f"Failed to perform command {' '.join(cmd)}. Reason:\n\n{e.stderr}"
-        )
+    UNKNOWN = "unknown"
 
 
 class PackageInfo:
     """Dataclass representing DNF package information."""
 
     def __init__(self, data: Dict[str, Union[str, _PackageState]]) -> None:
-        self.__data = data
+        self._data = data
 
     @property
     def installed(self) -> bool:
-        """Determine if package is marked 'installed'.
-
-        Returns:
-            (bool): True if package is installed; False if otherwise.
-        """
-        return self.__data["state"] == _PackageState.INSTALLED
+        """Determine if package is marked 'installed'."""
+        return self._data["state"] == _PackageState.INSTALLED
 
     @property
     def available(self) -> bool:
-        """Determine if package is marked 'available'.
-
-        Returns:
-            (bool): True if package is available; False if otherwise.
-        """
-        return self.__data["state"] == _PackageState.AVAILABLE
+        """Determine if package is marked 'available'."""
+        return self._data["state"] == _PackageState.AVAILABLE
 
     @property
     def absent(self) -> bool:
-        """Determine if package is marked 'absent'.
+        """Determine if package is marked 'absent'."""
+        return self._data["state"] == _PackageState.ABSENT
 
-        Returns:
-            (bool) True if package is absent; False if otherwise.
-        """
-        return self.__data["state"] == _PackageState.ABSENT
+    @property
+    def unknown(self) -> bool:
+        """Determine if package is marked 'unknown'."""
+        return self._data["state"] == _PackageState.UNKNOWN
 
     @property
     def name(self) -> str:
-        """Get name of package.
-
-        Returns:
-            (str): Name of package.
-        """
-        return self.__data["name"]
+        """Get name of package."""
+        return self._data["name"]
 
     @property
     def arch(self) -> Optional[str]:
-        """Get architecture of package.
-
-        Returns:
-            (Optional[str]):
-                Architecture of package. Defaults to None if package is absent.
-        """
-        return self.__data.get("arch", None)
+        """Get architecture of package."""
+        return self._data.get("arch", None)
 
     @property
     def epoch(self) -> Optional[str]:
-        """Get epoch of package.
-
-        Returns:
-            (Optional[str]):
-                Epoch of package. Defaults to None if package is absent.
-        """
-        return self.__data.get("epoch", None)
+        """Get epoch of package."""
+        return self._data.get("epoch", None)
 
     @property
     def version(self) -> Optional[str]:
-        """Get version of package.
-
-        Returns:
-            (Optional[str]):
-                Version number of package. Defaults to None if package is absent.
-        """
-        return self.__data.get("version", None)
+        """Get version of package."""
+        return self._data.get("version", None)
 
     @property
-    def fullversion(self) -> Optional[str]:
-        """Get full version of package.
-
-        Returns:
-            (Optional[str]):
-                Full version of package. Defaults to None if package is absent.
-        """
+    def full_version(self) -> Optional[str]:
+        """Get full version of package."""
         if self.absent:
             return None
 
-        return (
-            f"{(f'{self.epoch}:' if self.epoch else '')}"
-            f"{self.version}{(f'-{self.release}' if self.release else '')}"
-        )
+        full_version = [self.version, f"-{self.release}"]
+        if self.epoch:
+            full_version.insert(0, f"{self.epoch}:")
+
+        return "".join(full_version)
 
     @property
     def release(self) -> Optional[str]:
-        """Get release of package.
-
-        Returns:
-            (Optional[str]):
-                Release of package. Defaults to None if package is absent.
-        """
-        return self.__data.get("release", None)
+        """Get release of package."""
+        return self._data.get("release", None)
 
     @property
     def repo(self) -> Optional[str]:
-        """Get repository package is from.
-
-        Returns:
-            (Optional[str]):
-                Repository of package: Defaults to None if package is absent.
-        """
-        return self.__data.get("repo", None)
+        """Get repository package is from."""
+        return self._data.get("repo", None)
 
 
-def _load_cache(
-    cache_type: Literal["installed", "available"]
-) -> List[Dict[str, Union[str, _PackageState]]]:
-    """Load DNF cache information.
+def version() -> str:
+    """Get version of `dnf` executable."""
+    return StringIO(_dnf("--version")).readline().strip("\n")
+
+
+def installed() -> bool:
+    """Determine if the `dnf` executable is available on PATH."""
+    return shutil.which("dnf") is not None
+
+
+def update() -> None:
+    """Update all packages on the system."""
+    _dnf("update")
+
+
+def upgrade(*packages: str) -> None:
+    """Upgrade one or more packages.
 
     Args:
-        cache_type (Literal["installed", "available"]):
-            Cache information category to load.
+        *packages (str): Packages to upgrade on system.
+    """
+    if len(packages) == 0:
+        raise ExecutionError("No packages specified.")
+    _dnf("upgrade", *packages)
 
-    Raises:
-        DNFExecutionError: Raised if incorrect cache type is passed.
+
+def install(*packages: Union[str, os.PathLike]) -> None:
+    """Install one or more packages.
+
+    Args:
+        *packages (Union[str, os.PathLine]): Packages to install on the system.
+    """
+    if len(packages) == 0:
+        raise TypeError("No packages specified.")
+    _dnf("install", *packages)
+
+
+def remove(*packages: str) -> None:
+    """Remove one or more packages from the system.
+
+    Args:
+        *packages (str): Packages to remove from system.
+    """
+    if len(packages) == 0:
+        raise TypeError("No packages specified.")
+    _dnf("remove", *packages)
+
+
+def purge(*packages: str) -> None:
+    """Purge one or more packages from the system.
+
+    Args:
+        *packages (str): Packages to purge from system.
+    """
+    if len(packages) == 0:
+        raise TypeError("No packages specified.")
+    _dnf("remove", *packages)
+
+
+def fetch(package: str) -> PackageInfo:
+    """Fetch information about a package.
+
+    Args:
+        package (str): Package to get information about.
 
     Returns:
-        (List[Dict[str, Union[str, _PackageState]]]):
-            Loaded cache information.
+        PackageInfo: Information about package.
     """
-    if cache_type not in ["installed", "available"]:
-        raise DNFExecutionError(
-            f"Cache type must be either installed or available, not {cache_type}"
-        )
+    try:
+        status, info = _dnf("list", "-q", package).split("\n")[:2]  # Only take top two lines.
+        pkg_name, pkg_version, pkg_repo = info.split()
+        name, arch = pkg_name.rsplit(".", 1)
+        epoch, version, release = re.match(r"(?:(.*):)?(.*)-(.*)", pkg_version).groups()
+        if "Installed" in status:
+            state = _PackageState.INSTALLED
+        elif "Available" in status:
+            state = _PackageState.AVAILABLE
+        else:
+            state = _PackageState.UNKNOWN
 
-    result = []
-    state = {"installed": _PackageState.INSTALLED, "available": _PackageState.AVAILABLE}
-    for pkg_name, pkg_version, pkg_repo in itertools.filterfalse(
-        lambda x: len(x) != 3,
-        [
-            line.strip("\n").strip().split()
-            for line in StringIO(
-                _dnf("list", postargs=[f"--{cache_type}"]).stdout.strip("\n"),
-            )
-        ],
-    ):
-        placeholder = pkg_name.split(".")
-        epoch = None  # Not every DNF package has an epoch.
-        charset, buffer = deque(itertools.chain(pkg_version)), []
-        while charset:
-            char = charset.popleft()
-            if char == ":":
-                epoch = "".join(buffer)
-                buffer.clear()
-            elif char == "-":
-                version = "".join(buffer)
-                buffer.clear()
-            else:
-                buffer.append(char)
-
-        result.append(
+        return PackageInfo(
             {
-                "name": ".".join(placeholder[:-1]),
-                "arch": ".".join(placeholder[-1:]),
+                "name": name,
+                "arch": arch,
                 "epoch": epoch,
                 "version": version,
-                "release": "".join(buffer),
+                "release": release,
                 "repo": pkg_repo[1:] if pkg_repo.startswith("@") else pkg_repo,
-                "state": state[cache_type],
+                "state": state,
             }
         )
 
-    return result
+    except ExecutionError:
+        return PackageInfo({"name": package, "state": _PackageState.ABSENT})
 
 
-class _Cache:
-    """Track the current state of the DNF package cache."""
-
-    def __new__(cls) -> "_Cache":
-        """Create new  _Cache object.
-
-        Returns:
-            (_Cache): New _Cache object.
-        """
-        if not hasattr(cls, f"{cls.__name__}__instance"):
-            cls.__instance = super(_Cache, cls).__new__(cls)
-            cls.__instance.__initialized = False
-        return cls.__instance
-
-    def __init__(self) -> None:
-        if self.__initialized:
-            return
-
-        self.__initialized = True
-        self.refresh()
-
-    @property
-    def installed(self) -> List[Dict[str, Union[str, _PackageState]]]:
-        """Get installed packages.
-
-        Returns:
-            (List[Dict[str, Union[str, _PackageState]]]):
-                Cache of installed packages.
-        """
-        return copy.deepcopy(self.__installed)
-
-    @property
-    def available(self) -> List[Dict[str, Union[str, _PackageState]]]:
-        """Get available packages.
-
-        Returns:
-            (List[Dict[str, Union[str, _PackageState]]]):
-                Cache of available packages.
-        """
-        return copy.deepcopy(self.__available)
-
-    def refresh(self) -> None:
-        """Refresh current package cache."""
-        with ThreadPoolExecutor() as executor:
-            installed = executor.submit(_load_cache, "installed")
-            available = executor.submit(_load_cache, "available")
-            self.__installed = installed.result()
-            self.__available = available.result()
-
-
-def _refresh(func: Callable) -> Callable:
-    """Refresh cache after function call.
+def add_repo(repo: str) -> None:
+    """Add a new repository to DNF.
 
     Args:
-        func (Callable): Function to wrap.
+        repo (str): URL of new repository to add.
     """
-
-    @wraps(func)
-    def wrapper(*args, **kwargs) -> None:
-        func(*args, **kwargs)
-        _Cache().refresh()
-
-    return wrapper
+    if not fetch("dnf-plugins-core").installed:
+        install("dnf-plugins-core")
+    _dnf("config-manager", "--add-repo", repo)
 
 
-def _search(
-    cache: List[Dict[str, Union[str, _PackageState]]], name: str
-) -> Optional[Dict[str, Union[str, _PackageState]]]:
-    """Search DNF package cache.
+def _dnf(*args: str) -> str:
+    """Execute a DNF command.
 
     Args:
-        cache (List[Dict[str, Union[str, _PackageState]]]):
-            DNF package cache to search.
-        name (str):
-            Name of package to locate.
+        *args (str): Arguments to pass to `dnf` executable.
+
+    Raises:
+        ExecutionError: Raised if DNF command execution fails.
 
     Returns:
-        (Optional[Dict[str, Union[str, _PackageState]]]):
-            Located cache entry. Returns None if package is not found in cache.
+        str: Captured stdout of executed DNF command.
     """
-    for entry in cache:
-        if entry["name"] == name:
-            return entry
+    if not installed():
+        raise ExecutionError(f"dnf not found on PATH {os.getenv('PATH')}")
 
-    return None
-
-
-class _MetaDNF(type):
-    """Metaclass for `dnf`.
-
-    Notes:
-        This metaclass will raise an ImportError if the dnf executable
-        is not found on your PATH.
-    """
-
-    def __new__(cls, name, bases, attrs) -> "_MetaDNF":
-        if shutil.which("dnf") is None:
-            raise ImportError(
-                (
-                    f"Executable dnf not found on PATH {os.getenv('PATH')}. "
-                    "Cannot import dnf library."
-                )
-            )
-
-        # Install necessary commands needed by charm library.
-        _dnf("install", args=["dnf-plugins-core"])
-
-        return super(_MetaDNF, cls).__new__(cls, name, bases, attrs)
-
-    @property
-    def version(cls) -> str:
-        """Get version of DNF package manager.
-
-        Returns:
-            (str): Version of DNF.
-        """
-        return StringIO(_dnf("", preargs=["--version"]).stdout).readline().strip("\n")
-
-    def __getitem__(cls, package_name: str) -> PackageInfo:
-        """Get information about DNF package.
-
-        Args:
-            package_name (str): Name of package.
-
-        Returns:
-            (PackageInfo): DNF package information.
-        """
-        # Package cache can be large so perform searches in threads.
-        with ThreadPoolExecutor() as executor:
-            installed = executor.submit(_search, _Cache().installed, package_name)
-            available = executor.submit(_search, _Cache().available, package_name)
-
-            # See if package is in installed first.
-            result = installed.result()
-            if result:
-                return PackageInfo(result)
-
-            # If not installed, check available.
-            result = available.result()
-            if result:
-                return PackageInfo(result)
-
-            # If not in either installed or available, return default.
-            return PackageInfo({"name": package_name, "state": _PackageState.ABSENT})
-
-
-class dnf(metaclass=_MetaDNF):  # noqa N802
-    @staticmethod
-    @_refresh
-    def update() -> None:
-        """Update all packages on the system."""
-        _dnf("update")
-
-    @staticmethod
-    @_refresh
-    def upgrade(*packages: str) -> None:
-        """Upgrade one or more packages.
-
-        Args:
-            *packages (str): Packages to upgrade on system.
-        """
-        if len(packages) == 0:
-            raise DNFExecutionError("No packages specified.")
-        _dnf("upgrade", args=[*packages])
-
-    @staticmethod
-    @_refresh
-    def install(*packages: Union[str, os.PathLike]) -> None:
-        """Install one or more packages.
-
-        Args:
-            *packages (Union[str, os.PathLine]):
-                Packages to install on the system.
-        """
-        if len(packages) == 0:
-            raise DNFExecutionError("No packages specified.")
-        _dnf("install", args=[*packages])
-
-    @staticmethod
-    @_refresh
-    def remove(*packages: str) -> None:
-        """Remove one or more packages from the system.
-
-        Args:
-            *packages (str): Packages to remove from system.
-        """
-        if len(packages) == 0:
-            raise DNFExecutionError("No packages specified.")
-        _dnf("remove", args=[*packages])
-
-    @staticmethod
-    @_refresh
-    def purge(*packages: str) -> None:
-        """Purge one or more packages from the system.
-
-        Args:
-            *packages (str): Packages to purge from system.
-        """
-        if len(packages) == 0:
-            raise DNFExecutionError("No packages specified.")
-        _dnf("remove", args=[*packages])
-
-    @staticmethod
-    @_refresh
-    def add_repo(repo: str) -> None:
-        """Add a new repository to DNF.
-
-        Args:
-            repo (str): URL of new repository to add.
-        """
-        _dnf("config-manager", postargs=["--add-repo"], args=[repo])
+    cmd = ["dnf", "-y", *args]
+    try:
+        return subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+            check=True,
+        ).stdout.strip("\n")
+    except subprocess.CalledProcessError as e:
+        raise ExecutionError(f"{e} Reason:\n{e.stderr}")

--- a/lib/charms/operator_libs_linux/v0/dnf.py
+++ b/lib/charms/operator_libs_linux/v0/dnf.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Abstractions for system's DNF package information and repositories."""
+
+import copy
+import itertools
+import os
+import shutil
+import subprocess
+from collections import deque
+from concurrent.futures import ThreadPoolExecutor
+from enum import Enum
+from functools import wraps
+from io import StringIO
+from typing import Callable, Dict, List, Literal, Optional, Union
+
+
+class _PackageState(Enum):
+    INSTALLED = "installed"
+    AVAILABLE = "available"
+    ABSENT = "absent"
+
+
+class DNFExecutionError(Exception):
+    """Raise when dnf encounters an execution error."""
+
+
+def _dnf(
+    command: str,
+    args: Optional[Union[Union[str, os.PathLike], List[Union[str, os.PathLike]]]] = None,
+    preargs: Optional[List[str]] = None,
+    postargs: Optional[List[str]] = None,
+) -> subprocess.CompletedProcess[str]:
+    """Execute DNF command.
+
+    Args:
+        command (str): Command to execute.
+        args (Optional[Union[Union[str, os.PathLike], List[Union[str, os.PathLike]]]]):
+            Arguments to operate on. (Default: None).
+        preargs (Optional[List[str]], optional):
+            Optional arguments to prepend before command. (Default: None).
+        postargs (Optional[List[str]], optional):
+            Optional arguments to append after command. (Default: None).
+
+    Raises:
+        DNFExecutionError: Raised if specified DNF command fails to execute.
+
+    Returns:
+        (subprocess.CompletedProcess[str]):
+            returncode, stdout, and stderr of completed DNF command.
+    """
+    args = [args] if type(args) == str else args if type(args) == list else []
+    preargs = preargs if preargs is not None else []
+    postargs = postargs if postargs is not None else []
+    cmd = ["dnf", "-y", *preargs, command, *postargs, *args]
+    try:
+        return subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        )
+    except subprocess.CalledProcessError as e:
+        raise DNFExecutionError(
+            f"Failed to perform command {' '.join(cmd)}. Reason:\n\n{e.stderr}"
+        )
+
+
+class PackageInfo:
+    """Dataclass representing DNF package information."""
+
+    def __init__(self, data: Dict[str, Union[str, _PackageState]]) -> None:
+        self.__data = data
+
+    @property
+    def installed(self) -> bool:
+        """Determine if package is marked 'installed'.
+
+        Returns:
+            (bool): True if package is installed; False if otherwise.
+        """
+        return self.__data["state"] == _PackageState.INSTALLED
+
+    @property
+    def available(self) -> bool:
+        """Determine if package is marked 'available'.
+
+        Returns:
+            (bool): True if package is available; False if otherwise.
+        """
+        return self.__data["state"] == _PackageState.AVAILABLE
+
+    @property
+    def absent(self) -> bool:
+        """Determine if package is marked 'absent'.
+
+        Returns:
+            (bool) True if package is absent; False if otherwise.
+        """
+        return self.__data["state"] == _PackageState.ABSENT
+
+    @property
+    def name(self) -> str:
+        """Get name of package.
+
+        Returns:
+            (str): Name of package.
+        """
+        return self.__data["name"]
+
+    @property
+    def arch(self) -> Optional[str]:
+        """Get architecture of package.
+
+        Returns:
+            (Optional[str]):
+                Architecture of package. Defaults to None if package is absent.
+        """
+        return self.__data.get("arch", None)
+
+    @property
+    def epoch(self) -> Optional[str]:
+        """Get epoch of package.
+
+        Returns:
+            (Optional[str]):
+                Epoch of package. Defaults to None if package is absent.
+        """
+        return self.__data.get("epoch", None)
+
+    @property
+    def version(self) -> Optional[str]:
+        """Get version of package.
+
+        Returns:
+            (Optional[str]):
+                Version number of package. Defaults to None if package is absent.
+        """
+        return self.__data.get("version", None)
+
+    @property
+    def fullversion(self) -> Optional[str]:
+        """Get full version of package.
+
+        Returns:
+            (Optional[str]):
+                Full version of package. Defaults to None if package is absent.
+        """
+        if self.absent:
+            return None
+
+        return (
+            f"{(f'{self.epoch}:' if self.epoch else '')}"
+            f"{self.version}{(f'-{self.release}' if self.release else '')}"
+        )
+
+    @property
+    def release(self) -> Optional[str]:
+        """Get release of package.
+
+        Returns:
+            (Optional[str]):
+                Release of package. Defaults to None if package is absent.
+        """
+        return self.__data.get("release", None)
+
+    @property
+    def repo(self) -> Optional[str]:
+        """Get repository package is from.
+
+        Returns:
+            (Optional[str]):
+                Repository of package: Defaults to None if package is absent.
+        """
+        return self.__data.get("repo", None)
+
+
+def _load_cache(
+    cache_type: Literal["installed", "available"]
+) -> List[Dict[str, Union[str, _PackageState]]]:
+    """Load DNF cache information.
+
+    Args:
+        cache_type (Literal["installed", "available"]):
+            Cache information category to load.
+
+    Raises:
+        DNFExecutionError: Raised if incorrect cache type is passed.
+
+    Returns:
+        (List[Dict[str, Union[str, _PackageState]]]):
+            Loaded cache information.
+    """
+    if cache_type not in ["installed", "available"]:
+        raise DNFExecutionError(
+            f"Cache type must be either installed or available, not {cache_type}"
+        )
+
+    result = []
+    state = {"installed": _PackageState.INSTALLED, "available": _PackageState.AVAILABLE}
+    for pkg_name, pkg_version, pkg_repo in itertools.filterfalse(
+        lambda x: len(x) != 3,
+        [
+            line.strip("\n").strip().split()
+            for line in StringIO(
+                _dnf("list", postargs=[f"--{cache_type}"]).stdout.strip("\n"),
+            )
+        ],
+    ):
+        placeholder = pkg_name.split(".")
+        epoch = None  # Not every DNF package has an epoch.
+        charset, buffer = deque(itertools.chain(pkg_version)), []
+        while charset:
+            char = charset.popleft()
+            if char == ":":
+                epoch = "".join(buffer)
+                buffer.clear()
+            elif char == "-":
+                version = "".join(buffer)
+                buffer.clear()
+            else:
+                buffer.append(char)
+
+        result.append(
+            {
+                "name": ".".join(placeholder[:-1]),
+                "arch": ".".join(placeholder[-1:]),
+                "epoch": epoch,
+                "version": version,
+                "release": "".join(buffer),
+                "repo": pkg_repo[1:] if pkg_repo.startswith("@") else pkg_repo,
+                "state": state[cache_type],
+            }
+        )
+
+    return result
+
+
+class _Cache:
+    """Track the current state of the DNF package cache."""
+
+    def __new__(cls) -> "_Cache":
+        """Create new  _Cache object.
+
+        Returns:
+            (_Cache): New _Cache object.
+        """
+        if not hasattr(cls, f"{cls.__name__}__instance"):
+            cls.__instance = super(_Cache, cls).__new__(cls)
+            cls.__instance.__initialized = False
+        return cls.__instance
+
+    def __init__(self) -> None:
+        if self.__initialized:
+            return
+
+        self.__initialized = True
+        self.refresh()
+
+    @property
+    def installed(self) -> List[Dict[str, Union[str, _PackageState]]]:
+        """Get installed packages.
+
+        Returns:
+            (List[Dict[str, Union[str, _PackageState]]]):
+                Cache of installed packages.
+        """
+        return copy.deepcopy(self.__installed)
+
+    @property
+    def available(self) -> List[Dict[str, Union[str, _PackageState]]]:
+        """Get available packages.
+
+        Returns:
+            (List[Dict[str, Union[str, _PackageState]]]):
+                Cache of available packages.
+        """
+        return copy.deepcopy(self.__available)
+
+    def refresh(self) -> None:
+        """Refresh current package cache."""
+        with ThreadPoolExecutor() as executor:
+            installed = executor.submit(_load_cache, "installed")
+            available = executor.submit(_load_cache, "available")
+            self.__installed = installed.result()
+            self.__available = available.result()
+
+
+def _refresh(func: Callable) -> Callable:
+    """Refresh cache after function call.
+
+    Args:
+        func (Callable): Function to wrap.
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs) -> None:
+        func(*args, **kwargs)
+        _Cache().refresh()
+
+    return wrapper
+
+
+def _search(
+    cache: List[Dict[str, Union[str, _PackageState]]], name: str
+) -> Optional[Dict[str, Union[str, _PackageState]]]:
+    """Search DNF package cache.
+
+    Args:
+        cache (List[Dict[str, Union[str, _PackageState]]]):
+            DNF package cache to search.
+        name (str):
+            Name of package to locate.
+
+    Returns:
+        (Optional[Dict[str, Union[str, _PackageState]]]):
+            Located cache entry. Returns None if package is not found in cache.
+    """
+    for entry in cache:
+        if entry["name"] == name:
+            return entry
+
+    return None
+
+
+class _MetaDNF(type):
+    """Metaclass for `dnf`.
+
+    Notes:
+        This metaclass will raise an ImportError if the dnf executable
+        is not found on your PATH.
+    """
+
+    def __new__(cls, name, bases, attrs) -> "_MetaDNF":
+        if shutil.which("dnf") is None:
+            raise ImportError(
+                (
+                    f"Executable dnf not found on PATH {os.getenv('PATH')}. "
+                    "Cannot import dnf library."
+                )
+            )
+
+        return super(_MetaDNF, cls).__new__(cls, name, bases, attrs)
+
+    @property
+    def version(cls) -> str:
+        """Get version of DNF package manager.
+
+        Returns:
+            (str): Version of DNF.
+        """
+        return StringIO(_dnf("", preargs=["--version"]).stdout).readline().strip("\n")
+
+    def __getitem__(cls, package_name: str) -> PackageInfo:
+        """Get information about DNF package.
+
+        Args:
+            package_name (str): Name of package.
+
+        Returns:
+            (PackageInfo): DNF package information.
+        """
+        # Package cache can be large so perform searches in threads.
+        with ThreadPoolExecutor() as executor:
+            installed = executor.submit(_search, _Cache().installed, package_name)
+            available = executor.submit(_search, _Cache().available, package_name)
+
+            # See if package is in installed first.
+            result = installed.result()
+            if result:
+                return PackageInfo(result)
+
+            # If not installed, check available.
+            result = available.result()
+            if result:
+                return PackageInfo(result)
+
+            # If not in either installed or available, return default.
+            return PackageInfo({"name": package_name, "state": _PackageState.ABSENT})
+
+
+class dnf(metaclass=_MetaDNF):  # noqa N802
+    @staticmethod
+    @_refresh
+    def update() -> None:
+        """Update all packages on the system."""
+        _dnf("update")
+
+    @staticmethod
+    @_refresh
+    def upgrade(*packages: str) -> None:
+        """Upgrade one or more packages.
+
+        Args:
+            *packages (str): Packages to upgrade on system.
+        """
+        if len(packages) == 0:
+            raise DNFExecutionError("No packages specified.")
+        _dnf("upgrade", args=[*packages])
+
+    @staticmethod
+    @_refresh
+    def install(*packages: Union[str, os.PathLike]) -> None:
+        """Install one or more packages.
+
+        Args:
+            *packages (Union[str, os.PathLine]):
+                Packages to install on the system.
+        """
+        if len(packages) == 0:
+            raise DNFExecutionError("No packages specified.")
+        _dnf("install", args=[*packages])
+
+    @staticmethod
+    @_refresh
+    def remove(*packages: str) -> None:
+        """Remove one or more packages from the system.
+
+        Args:
+            *packages (str): Packages to remove from system.
+        """
+        if len(packages) == 0:
+            raise DNFExecutionError("No packages specified.")
+        _dnf("remove", args=[*packages])
+
+    @staticmethod
+    @_refresh
+    def purge(*packages: str) -> None:
+        """Purge one or more packages from the system.
+
+        Args:
+            *packages (str): Packages to purge from system.
+        """
+        if len(packages) == 0:
+            raise DNFExecutionError("No packages specified.")
+        _dnf("purge", args=[*packages])
+
+    @staticmethod
+    @_refresh
+    def add_repo(repo: str) -> None:
+        """Add a new repository to DNF.
+
+        Args:
+            repo (str): URL of new repository to add.
+        """
+        _dnf("config-manager", postargs=["--add-repo"], args=[repo])

--- a/lib/charms/operator_libs_linux/v0/dnf.py
+++ b/lib/charms/operator_libs_linux/v0/dnf.py
@@ -87,7 +87,7 @@ def upgrade(*packages: Optional[str]) -> None:
     """Upgrade one or more packages.
 
     Args:
-        *packages (Optional[str]):
+        *packages:
             Packages to upgrade on system. If packages is omitted,
             upgrade all packages on the system.
     """
@@ -98,7 +98,7 @@ def install(*packages: Union[str, os.PathLike]) -> None:
     """Install one or more packages.
 
     Args:
-        *packages (Union[str, os.PathLike]): Packages to install on the system.
+        *packages: Packages to install on the system.
     """
     if not packages:
         raise TypeError("No packages specified.")
@@ -109,7 +109,7 @@ def remove(*packages: str) -> None:
     """Remove one or more packages from the system.
 
     Args:
-        *packages (str): Packages to remove from system.
+        *packages: Packages to remove from system.
     """
     if not packages:
         raise TypeError("No packages specified.")
@@ -120,7 +120,7 @@ def fetch(package: str) -> PackageInfo:
     """Fetch information about a package.
 
     Args:
-        package (str): Package to get information about.
+        package: Package to get information about.
 
     Returns:
         PackageInfo: Information about package.
@@ -174,7 +174,7 @@ def add_repo(repo: str) -> None:  # pragma: no cover
     """Add a new repository to DNF.
 
     Args:
-        repo (str): URL of new repository to add.
+        repo: URL of new repository to add.
     """
     if not fetch("dnf-plugins-core").installed:
         install("dnf-plugins-core")
@@ -185,7 +185,7 @@ def _dnf(*args: str) -> str:
     """Execute a DNF command.
 
     Args:
-        *args (str): Arguments to pass to `dnf` executable.
+        *args: Arguments to pass to `dnf` executable.
 
     Raises:
         Error: Raised if DNF command execution fails.

--- a/lib/charms/operator_libs_linux/v0/dnf.py
+++ b/lib/charms/operator_libs_linux/v0/dnf.py
@@ -12,7 +12,89 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Abstractions for system's DNF package information and repositories."""
+"""Abstractions for the system's DNF package information and repositories.
+
+This charm library contains abstractions and wrappers around Enterprise Linux
+(CentOS Stream, AlmaLinux, Rocky Linux, Cloud Linux, etc.) repositories and packages
+to provide an idiomatic and Pythonic mechanism for managing packages and repositories
+within machine charms deployed to an Enterprise Linux base.
+
+To install packages using the library:
+
+```python
+import charms.operator_libs_linux.v0.dnf as dnf
+
+try:
+    dnf.install("epel-release")
+    dnf.install("slurm-slurmd", "slurm-slurmctld", "slurm-slurmdbd", "slurm-slurmrestd")
+except dnf.Error:
+    logger.error("Failed to install requested packages.")
+```
+
+To upgrade specific packages and/or entire system using the library:
+
+```python
+import charms.operator_libs_linux.v0.dnf as dnf
+
+try:
+    # To upgrade a specific package.
+    dnf.upgrade("slurm-slurmd")
+    # To upgrade the whole system.
+    dnf.upgrade()
+except dnf.Error:
+    logger.error("Failed to perform requested package upgrades.")
+```
+
+__Important:__ If no packages are passed to `dnf.upgrade(...)`, all packages with newer
+versions available in the system's known repositories will be upgraded.
+
+To remove packages using the library:
+
+```python
+import charms.operator_libs_linux.v0.dnf as dnf
+
+try:
+    dnf.remove("slurm-slurmd", "slurm-slurmctld", "slurm-slurmdbd", "slurm-slurmrestd")
+    dnf.remove("epel-release")
+except dnf.Error:
+    logger.error("Failed to remove requested packages.")
+```
+
+Packages can have three possible states: installed, available, and absent. "installed"
+means that the package is currently installed on the system. "available" means that the
+package is available within the system's known package repositories, but is not currently
+installed. "absent" means that the package was not found either or the system on within
+the system's known package repositories.
+
+To find details of a specific package using the library:
+
+```python
+import charms.operator_libs_linux.v0.dnf as dnf
+
+try:
+    package = dnf.fetch("slurm-slurmd")
+    assert package.installed
+    assert package.version == "22.05.6"
+except AssertionError:
+    logger.error("Package slurm-slurmd is not installed or is not expected version.")
+```
+
+__Important:__ `dnf.fetch(...)` will only match exact package names, not aliases. Ensure
+that you are using the exact package name, otherwise the fetched package will be marked
+as "absent". e.g. use the exact package name "python2.7" and not the alias "python2".
+
+To add a new package repository using the library:
+
+```python
+import charms.operator_libs_linux.v0.dnf as dnf
+
+try:
+    dnf.add_repo("http://mirror.stream.centos.org/9-stream/HighAvailability/x86_64/os")
+    dnf.install("pacemaker")
+except dnf.Error:
+    logger.error("Failed to install pacemaker package from HighAvailability repository.")
+```
+"""
 
 import os
 import re

--- a/lib/charms/operator_libs_linux/v0/dnf.py
+++ b/lib/charms/operator_libs_linux/v0/dnf.py
@@ -353,6 +353,9 @@ class _MetaDNF(type):
                 )
             )
 
+        # Install necessary commands needed by charm library.
+        _dnf("install", args=["dnf-plugins-core"])
+
         return super(_MetaDNF, cls).__new__(cls, name, bases, attrs)
 
     @property

--- a/lib/charms/operator_libs_linux/v0/dnf.py
+++ b/lib/charms/operator_libs_linux/v0/dnf.py
@@ -22,6 +22,16 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Optional, Union
 
+# The unique Charmhub library identifier, never change it
+LIBID = "1e93f444444d4a4a8df06c1c16b33aaf"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
 
 class Error(Exception):
     """Raise when dnf encounters an execution error."""

--- a/lib/charms/operator_libs_linux/v0/dnf.py
+++ b/lib/charms/operator_libs_linux/v0/dnf.py
@@ -170,7 +170,7 @@ def fetch(package: str) -> PackageInfo:
         return PackageInfo(name=package)
 
 
-def add_repo(repo: str) -> None:
+def add_repo(repo: str) -> None:  # pragma: no cover
     """Add a new repository to DNF.
 
     Args:

--- a/lib/charms/operator_libs_linux/v0/dnf.py
+++ b/lib/charms/operator_libs_linux/v0/dnf.py
@@ -98,7 +98,7 @@ def install(*packages: Union[str, os.PathLike]) -> None:
     """Install one or more packages.
 
     Args:
-        *packages (Union[str, os.PathLine]): Packages to install on the system.
+        *packages (Union[str, os.PathLike]): Packages to install on the system.
     """
     if not packages:
         raise TypeError("No packages specified.")

--- a/lib/charms/operator_libs_linux/v0/dnf.py
+++ b/lib/charms/operator_libs_linux/v0/dnf.py
@@ -446,7 +446,7 @@ class dnf(metaclass=_MetaDNF):  # noqa N802
         """
         if len(packages) == 0:
             raise DNFExecutionError("No packages specified.")
-        _dnf("purge", args=[*packages])
+        _dnf("remove", args=[*packages])
 
     @staticmethod
     @_refresh

--- a/tests/integration/test_dnf.py
+++ b/tests/integration/test_dnf.py
@@ -12,7 +12,7 @@ from cleantest.data import File
 from cleantest.provider import LXDArchon, lxd
 
 
-@lxd.target("test-ubuntu")
+@lxd.target("test-ubuntu-jammy")
 def fail_on_ubuntu() -> None:
     import sys
 
@@ -24,7 +24,7 @@ def fail_on_ubuntu() -> None:
         sys.exit(0)
 
 
-@lxd.target("test-rocky")
+@lxd.target("test-alma-9")
 def install_package() -> None:
     import sys
 
@@ -44,7 +44,7 @@ def install_package() -> None:
         sys.exit(1)
 
 
-@lxd.target("test-rocky")
+@lxd.target("test-alma-9")
 def query_dnf_and_package() -> None:
     import sys
 
@@ -68,7 +68,7 @@ def query_dnf_and_package() -> None:
         sys.exit(1)
 
 
-@lxd.target("test-rocky")
+@lxd.target("test-alma-9")
 def remove_package() -> None:
     import sys
 
@@ -84,7 +84,7 @@ def remove_package() -> None:
         sys.exit(1)
 
 
-@lxd.target("test-rocky")
+@lxd.target("test-alma-9")
 def check_absent() -> None:
     import sys
 
@@ -106,14 +106,14 @@ def check_absent() -> None:
         sys.exit(1)
 
 
-@lxd.target("test-rocky")
+@lxd.target("test-alma-9")
 def add_repo() -> None:
     import sys
 
     try:
         from charms.operator_libs_linux.v0.dnf import dnf
 
-        dnf.add_repo("https://dl.rockylinux.org/pub/rocky/9.1/HighAvailability/x86_64/os/")
+        dnf.add_repo("https://repo.almalinux.org/almalinux/9/HighAvailability/x86_64/os")
         dnf.install("pacemaker")
         assert dnf["pacemaker"].installed is True
         sys.exit(0)
@@ -125,8 +125,8 @@ class TestDNF(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         archon = LXDArchon()
-        archon.add("test-ubuntu", image="ubuntu-jammy-amd64")
-        archon.add("test-rocky", image="rockylinux-9-amd64")
+        archon.add("test-ubuntu-jammy", image="ubuntu-jammy-amd64")
+        archon.add("test-alma-9", image="almalinux-9-amd64")
         charm_library = (
             pathlib.Path(__file__).parent.parent.parent
             / "lib"
@@ -136,9 +136,9 @@ class TestDNF(unittest.TestCase):
             / "dnf.py"
         )
         charm_lib_path = "/root/lib/charms/operator_libs_linux/v0"
-        archon.execute(["test-ubuntu", "test-rocky"], f"mkdir -p {charm_lib_path}")
-        archon.push("test-ubuntu", data_obj=File(charm_library, f"{charm_lib_path}/dnf.py"))
-        archon.push("test-rocky", data_obj=File(charm_library, f"{charm_lib_path}/dnf.py"))
+        archon.execute(["test-ubuntu-jammy", "test-alma-9"], f"mkdir -p {charm_lib_path}")
+        archon.push("test-ubuntu-jammy", data_obj=File(charm_library, f"{charm_lib_path}/dnf.py"))
+        archon.push("test-alma-9", data_obj=File(charm_library, f"{charm_lib_path}/dnf.py"))
         Env().add({"PYTHONPATH": "/root/lib"})
 
     def test_fail_on_ubuntu(self) -> None:

--- a/tests/integration/test_dnf.py
+++ b/tests/integration/test_dnf.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Integration tests for dnf charm library."""
+
+import pathlib
+import unittest
+
+from cleantest.control import Env
+from cleantest.data import File
+from cleantest.provider import LXDArchon, lxd
+
+
+@lxd.target("test-ubuntu")
+def fail_on_ubuntu() -> None:
+    import sys
+
+    try:
+        from charms.operator_libs_linux.v0.dnf import dnf  # noqa F401
+
+        sys.exit(1)
+    except ImportError:
+        sys.exit(0)
+
+
+@lxd.target("test-rocky")
+def install_package() -> None:
+    import sys
+
+    try:
+        from charms.operator_libs_linux.v0.dnf import dnf
+
+        dnf.update()
+        dnf.install("epel-release")
+        dnf.install("slurm-slurmd", "slurm-slurmctld", "slurm-slurmdbd", "slurm-slurmrestd")
+        assert dnf["epel-release"].installed is True
+        assert dnf["slurm-slurmd"].installed is True
+        assert dnf["slurm-slurmctld"].installed is True
+        assert dnf["slurm-slurmdbd"].installed is True
+        assert dnf["slurm-slurmrestd"].installed is True
+        sys.exit(0)
+    except (ImportError, AssertionError):
+        sys.exit(1)
+
+
+@lxd.target("test-rocky")
+def query_dnf_and_package() -> None:
+    import sys
+
+    try:
+        from charms.operator_libs_linux.v0.dnf import dnf
+
+        assert dnf.version == "4.12.0"
+        package = dnf["slurm-slurmd"]
+        assert package.installed is True
+        assert package.available is False
+        assert package.absent is False
+        assert package.name == "slurm-slurmd"
+        assert package.arch == "x86_64"
+        assert package.epoch is None
+        assert package.version == "22.05.6"
+        assert package.release == "3.el9"
+        assert package.fullversion == "22.05.6-3.el9"
+        assert package.repo == "epel"
+        sys.exit(0)
+    except (ImportError, AssertionError):
+        sys.exit(1)
+
+
+@lxd.target("test-rocky")
+def remove_package() -> None:
+    import sys
+
+    try:
+        from charms.operator_libs_linux.v0.dnf import dnf
+
+        dnf.remove("slurm-slurmdbd")
+        dnf.purge("slurm-slurmrestd")
+        assert dnf["slurm-slurmdbd"].available is True
+        assert dnf["slurm-slurmrestd"].available is True
+        sys.exit(0)
+    except (ImportError, AssertionError):
+        sys.exit(1)
+
+
+@lxd.target("test-rocky")
+def check_absent() -> None:
+    import sys
+
+    try:
+        from charms.operator_libs_linux.v0.dnf import dnf
+
+        bogus = dnf["nuccitheboss"]
+        assert bogus.installed is False
+        assert bogus.available is False
+        assert bogus.absent is True
+        assert bogus.name == "nuccitheboss"
+        assert bogus.arch is None
+        assert bogus.epoch is None
+        assert bogus.version is None
+        assert bogus.release is None
+        assert bogus.fullversion is None
+        assert bogus.repo is None
+    except (ImportError, AssertionError):
+        sys.exit(1)
+
+
+@lxd.target("test-rocky")
+def add_repo() -> None:
+    import sys
+
+    try:
+        from charms.operator_libs_linux.v0.dnf import dnf
+
+        dnf.add_repo("https://dl.rockylinux.org/pub/rocky/9.1/HighAvailability/x86_64/os/")
+        dnf.install("pacemaker")
+        assert dnf["pacemaker"].installed is True
+        sys.exit(0)
+    except (ImportError, AssertionError):
+        sys.exit(1)
+
+
+class TestDNF(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        archon = LXDArchon()
+        archon.add("test-ubuntu", image="ubuntu-jammy-amd64")
+        archon.add("test-rocky", image="rockylinux-9-amd64")
+        charm_library = (
+            pathlib.Path(__file__).parent.parent.parent
+            / "lib"
+            / "charms"
+            / "operator_libs_linux"
+            / "v0"
+            / "dnf.py"
+        )
+        charm_lib_path = "/root/lib/charms/operator_libs_linux/v0"
+        archon.execute(["test-ubuntu", "test-rocky"], f"mkdir -p {charm_lib_path}")
+        archon.push("test-ubuntu", data_obj=File(charm_library, f"{charm_lib_path}/dnf.py"))
+        archon.push("test-rocky", data_obj=File(charm_library, f"{charm_lib_path}/dnf.py"))
+        Env().add({"PYTHONPATH": "/root/lib"})
+
+    def test_fail_on_ubuntu(self) -> None:
+        for name, result in fail_on_ubuntu():
+            self.assertEqual(result.exit_code, 0)
+
+    def test_install_package(self) -> None:
+        for name, result in install_package():
+            self.assertEqual(result.exit_code, 0)
+
+    def test_query_dnf(self) -> None:
+        for name, result in query_dnf_and_package():
+            self.assertEqual(result.exit_code, 0)
+
+    def test_remove_package(self) -> None:
+        for name, result in query_dnf_and_package():
+            self.assertEqual(result.exit_code, 0)
+
+    def test_check_absent(self) -> None:
+        for name, result in check_absent():
+            self.assertEqual(result.exit_code, 0)
+
+    def test_add_repo(self) -> None:
+        for name, result in add_repo():
+            self.assertEqual(result.exit_code, 0)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        LXDArchon().destroy()

--- a/tests/integration/test_dnf.py
+++ b/tests/integration/test_dnf.py
@@ -55,7 +55,6 @@ def query_dnf_and_package() -> None:
         assert package.installed
         assert not package.available
         assert not package.absent
-        assert not package.unknown
         assert package.name == "slurm-slurmd"
         assert package.arch == "x86_64"
         assert package.epoch is None
@@ -95,7 +94,6 @@ def check_absent() -> None:
         assert not bogus.installed
         assert not bogus.available
         assert bogus.absent
-        assert not bogus.unknown
         assert bogus.name == "nuccitheboss"
         assert bogus.arch is None
         assert bogus.epoch is None

--- a/tests/integration/test_dnf.py
+++ b/tests/integration/test_dnf.py
@@ -4,167 +4,58 @@
 
 """Integration tests for dnf charm library."""
 
-import pathlib
-import unittest
-
-from cleantest.control import Env
-from cleantest.data import File
-from cleantest.provider import LXDArchon, lxd
+import charms.operator_libs_linux.v0.dnf as dnf
 
 
-@lxd.target("test-ubuntu-jammy")
-def fail_on_ubuntu() -> None:
-    import sys
-
-    import charms.operator_libs_linux.v0.dnf as dnf
-
-    if not dnf.installed():
-        sys.exit(0)
-    sys.exit(1)
-
-
-@lxd.target("test-alma-9")
-def install_package() -> None:
-    import sys
-
-    try:
-        import charms.operator_libs_linux.v0.dnf as dnf
-
-        dnf.update()
-        dnf.install("epel-release")
-        dnf.install("slurm-slurmd", "slurm-slurmctld", "slurm-slurmdbd", "slurm-slurmrestd")
-        assert dnf.fetch("epel-release").installed
-        assert dnf.fetch("slurm-slurmd").installed
-        assert dnf.fetch("slurm-slurmctld").installed
-        assert dnf.fetch("slurm-slurmdbd").installed
-        assert dnf.fetch("slurm-slurmrestd").installed
-        sys.exit(0)
-    except AssertionError:
-        sys.exit(1)
+def test_install_package() -> None:
+    dnf.install("epel-release")
+    dnf.install("slurm-slurmd", "slurm-slurmctld", "slurm-slurmdbd", "slurm-slurmrestd")
+    assert dnf.fetch("epel-release").installed
+    assert dnf.fetch("slurm-slurmd").installed
+    assert dnf.fetch("slurm-slurmctld").installed
+    assert dnf.fetch("slurm-slurmdbd").installed
+    assert dnf.fetch("slurm-slurmrestd").installed
 
 
-@lxd.target("test-alma-9")
-def query_dnf_and_package() -> None:
-    import sys
-
-    try:
-        import charms.operator_libs_linux.v0.dnf as dnf
-
-        assert dnf.version() == "4.12.0"
-        package = dnf.fetch("slurm-slurmd")
-        assert package.installed
-        assert not package.available
-        assert not package.absent
-        assert package.name == "slurm-slurmd"
-        assert package.arch == "x86_64"
-        assert package.epoch is None
-        assert package.version == "22.05.6"
-        assert package.release == "3.el9"
-        assert package.full_version == "22.05.6-3.el9"
-        assert package.repo == "epel"
-        sys.exit(0)
-    except AssertionError:
-        sys.exit(1)
+def test_query_dnf_and_package() -> None:
+    assert dnf.version() == "4.14.0"
+    package = dnf.fetch("slurm-slurmd")
+    assert package.installed
+    assert not package.available
+    assert not package.absent
+    assert package.name == "slurm-slurmd"
+    assert package.arch == "x86_64"
+    assert package.epoch is None
+    assert package.version == "22.05.6"
+    assert package.release == "3.el9"
+    assert package.full_version == "22.05.6-3.el9"
+    assert package.repo == "epel"
 
 
-@lxd.target("test-alma-9")
-def remove_package() -> None:
-    import sys
-
-    try:
-        import charms.operator_libs_linux.v0.dnf as dnf
-
-        dnf.remove("slurm-slurmdbd")
-        dnf.purge("slurm-slurmrestd")
-        assert dnf.fetch("slurm-slurmdbd").available
-        assert dnf.fetch("slurm-slurmrestd").available
-        sys.exit(0)
-    except AssertionError:
-        sys.exit(1)
+def test_remove_package() -> None:
+    dnf.remove("slurm-slurmdbd")
+    dnf.remove("slurm-slurmd", "slurm-slurmrestd", "slurm-slurmctld")
+    assert dnf.fetch("slurm-slurmdbd").available
+    assert dnf.fetch("slurm-slurmd").available
+    assert dnf.fetch("slurm-slurmrestd").available
+    assert dnf.fetch("slurm-slurmctld").available
 
 
-@lxd.target("test-alma-9")
-def check_absent() -> None:
-    import sys
-
-    try:
-        import charms.operator_libs_linux.v0.dnf as dnf
-
-        bogus = dnf.fetch("nuccitheboss")
-        assert not bogus.installed
-        assert not bogus.available
-        assert bogus.absent
-        assert bogus.name == "nuccitheboss"
-        assert bogus.arch is None
-        assert bogus.epoch is None
-        assert bogus.version is None
-        assert bogus.release is None
-        assert bogus.full_version is None
-        assert bogus.repo is None
-        sys.exit(0)
-    except AssertionError:
-        sys.exit(1)
+def test_check_absent() -> None:
+    bogus = dnf.fetch("nuccitheboss")
+    assert not bogus.installed
+    assert not bogus.available
+    assert bogus.absent
+    assert bogus.name == "nuccitheboss"
+    assert bogus.arch is None
+    assert bogus.epoch is None
+    assert bogus.version is None
+    assert bogus.release is None
+    assert bogus.full_version is None
+    assert bogus.repo is None
 
 
-@lxd.target("test-alma-9")
-def add_repo() -> None:
-    import sys
-
-    try:
-        import charms.operator_libs_linux.v0.dnf as dnf
-
-        dnf.add_repo("https://repo.almalinux.org/almalinux/9/HighAvailability/x86_64/os")
-        dnf.install("pacemaker")
-        assert dnf.fetch("pacemaker").installed
-        sys.exit(0)
-    except AssertionError:
-        sys.exit(1)
-
-
-class TestDNF(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls) -> None:
-        archon = LXDArchon()
-        archon.add("test-ubuntu-jammy", image="ubuntu-jammy-amd64")
-        archon.add("test-alma-9", image="almalinux-9-amd64")
-        charm_library = (
-            pathlib.Path(__file__).parent.parent.parent
-            / "lib"
-            / "charms"
-            / "operator_libs_linux"
-            / "v0"
-            / "dnf.py"
-        )
-        charm_lib_path = "/root/lib/charms/operator_libs_linux/v0"
-        archon.execute(["test-ubuntu-jammy", "test-alma-9"], f"mkdir -p {charm_lib_path}")
-        archon.push("test-ubuntu-jammy", data_obj=File(charm_library, f"{charm_lib_path}/dnf.py"))
-        archon.push("test-alma-9", data_obj=File(charm_library, f"{charm_lib_path}/dnf.py"))
-        Env().add({"PYTHONPATH": "/root/lib"})
-
-    def test_fail_on_ubuntu(self) -> None:
-        for name, result in fail_on_ubuntu():
-            self.assertEqual(result.exit_code, 0)
-
-    def test_install_package(self) -> None:
-        for name, result in install_package():
-            self.assertEqual(result.exit_code, 0)
-
-    def test_query_dnf(self) -> None:
-        for name, result in query_dnf_and_package():
-            self.assertEqual(result.exit_code, 0)
-
-    def test_remove_package(self) -> None:
-        for name, result in remove_package():
-            self.assertEqual(result.exit_code, 0)
-
-    def test_check_absent(self) -> None:
-        for name, result in check_absent():
-            self.assertEqual(result.exit_code, 0)
-
-    def test_add_repo(self) -> None:
-        for name, result in add_repo():
-            self.assertEqual(result.exit_code, 0)
-
-    @classmethod
-    def tearDownClass(cls) -> None:
-        LXDArchon().destroy()
+def test_add_repo() -> None:
+    dnf.add_repo("http://mirror.stream.centos.org/9-stream/HighAvailability/x86_64/os")
+    dnf.install("pacemaker")
+    assert dnf.fetch("pacemaker").installed

--- a/tests/unit/test_dnf.py
+++ b/tests/unit/test_dnf.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for dnf charm library; test dnf without installing on an RPM-based instance."""
+
+import subprocess
+import unittest
+from unittest.mock import patch
+
+import charms.operator_libs_linux.v0.dnf as dnf
+
+example_version_output = """
+4.14.0
+  Installed: dnf-0:4.14.0-4.el9.noarch at Mon 06 Mar 2023 03:55:24 PM GMT
+  Built    : builder@centos.org at Fri 06 Jan 2023 02:23:17 PM GMT
+
+  Installed: rpm-0:4.16.1.3-22.el9.x86_64 at Mon 06 Mar 2023 03:55:23 PM GMT
+  Built    : builder@centos.org at Mon 19 Dec 2022 11:57:50 PM GMT
+""".strip(
+    "\n"
+)
+
+example_installed_output = """
+Installed Packages
+NetworkManager.x86_64 1:1.42.2-1.el9 @baseos
+""".strip(
+    "\n"
+)
+
+example_available_output = """
+Available Packages
+slurm-slurmd.x86_64 22.05.6-3.el9 epel
+""".strip(
+    "\n"
+)
+
+example_bad_state_output = """
+Obsolete Packages
+yowzah yowzah yowzah
+""".strip(
+    "\n"
+)
+
+example_bad_version_output = """
+Available Packages
+slurm-slurmd.x86_64 yowzah epel
+""".strip(
+    "\n"
+)
+
+
+class TestDNF(unittest.TestCase):
+    @patch("shutil.which", return_value=True)
+    def test_dnf_installed(self, _):
+        self.assertTrue(dnf.installed())
+
+    @patch("shutil.which", return_value=None)
+    @patch(
+        "subprocess.run",
+        side_effect=FileNotFoundError("[Errno 2] No such file or directory: 'dnf'"),
+    )
+    def test_dnf_not_installed(self, *_):
+        self.assertFalse(dnf.installed())
+        with self.assertRaises(dnf.Error):
+            dnf.upgrade()
+
+    @patch("charms.operator_libs_linux.v0.dnf._dnf", return_value=example_version_output)
+    def test_dnf_version(self, _):
+        self.assertEqual("4.14.0", dnf.version())
+
+    @patch(
+        "subprocess.run",
+        return_value=subprocess.CompletedProcess(
+            "dnf upgrade bogus", returncode=0, stdout="Success!"
+        ),
+    )
+    def test_upgrade(self, _):
+        dnf.upgrade()
+        dnf.upgrade("slurm-slurmd")
+
+    @patch(
+        "subprocess.run",
+        return_value=subprocess.CompletedProcess(
+            "dnf install bogus", returncode=0, stdout="Success!"
+        ),
+    )
+    def test_install(self, _):
+        dnf.install("slurm-slurmd")
+
+    def test_install_invalid_input(self):
+        with self.assertRaises(TypeError):
+            dnf.install()
+
+    @patch(
+        "subprocess.run",
+        return_value=subprocess.CompletedProcess(
+            "dnf remove bogus", returncode=0, stdout="Success!"
+        ),
+    )
+    def test_remove(self, _):
+        dnf.remove("slurm-slurmd")
+
+    def test_remove_invalid_input(self):
+        with self.assertRaises(TypeError):
+            dnf.remove()
+
+    @patch("charms.operator_libs_linux.v0.dnf._dnf", return_value=example_installed_output)
+    def test_fetch_installed(self, _):
+        x = dnf.fetch("NetworkManager")
+        self.assertTrue(x.installed)
+        self.assertFalse(x.available)
+        self.assertFalse(x.absent)
+        self.assertEqual(x.name, "NetworkManager")
+        self.assertEqual(x.arch, "x86_64")
+        self.assertEqual(x.epoch, "1")
+        self.assertEqual(x.version, "1.42.2")
+        self.assertEqual(x.release, "1.el9")
+        self.assertEqual(x.full_version, "1:1.42.2-1.el9")
+        self.assertEqual(x.repo, "baseos")
+
+    @patch("charms.operator_libs_linux.v0.dnf._dnf", return_value=example_available_output)
+    def test_fetch_available(self, _):
+        x = dnf.fetch("slurm-slurmd")
+        self.assertFalse(x.installed)
+        self.assertTrue(x.available)
+        self.assertFalse(x.absent)
+        self.assertEqual(x.name, "slurm-slurmd")
+        self.assertEqual(x.arch, "x86_64")
+        self.assertIsNone(x.epoch)
+        self.assertEqual(x.version, "22.05.6")
+        self.assertEqual(x.release, "3.el9")
+        self.assertEqual(x.full_version, "22.05.6-3.el9")
+        self.assertEqual(x.repo, "epel")
+
+    @patch(
+        "subprocess.run",
+        side_effect=subprocess.CalledProcessError(
+            1, "dnf list -q nuccitheboss", stderr="Error: No matching Packages to list"
+        ),
+    )
+    def test_fetch_absent(self, _):
+        x = dnf.fetch("nuccitheboss")
+        self.assertFalse(x.installed)
+        self.assertFalse(x.available)
+        self.assertTrue(x.absent)
+        self.assertEqual(x.name, "nuccitheboss")
+        self.assertIsNone(x.arch)
+        self.assertIsNone(x.epoch)
+        self.assertIsNone(x.version)
+        self.assertIsNone(x.release)
+        self.assertIsNone(x.full_version)
+        self.assertIsNone(x.repo)
+
+    @patch("charms.operator_libs_linux.v0.dnf._dnf", return_value=example_bad_state_output)
+    def test_fetch_bad_state(self, _):
+        self.assertTrue(dnf.fetch("yowzah").absent)
+
+    @patch("charms.operator_libs_linux.v0.dnf._dnf", return_value=example_bad_version_output)
+    def test_fetch_bad_version(self, _):
+        self.assertTrue(dnf.fetch("yowzah").absent)

--- a/tox.ini
+++ b/tox.ini
@@ -92,7 +92,9 @@ description = Run integration tests
 deps =
     pytest
 commands =
-    pytest -v --tb native --ignore={[vars]tst_dir}unit --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore={[vars]tst_dir}unit \
+        --ignore={[vars]tst_dir}integration/test_dnf.py \
+        --log-cli-level=INFO -s {posargs}
 
 [testenv:integration-but-with-cleantest]
 description = Run integration tests using cleantest

--- a/tox.ini
+++ b/tox.ini
@@ -96,7 +96,7 @@ commands =
         --ignore={[vars]tst_dir}integration/test_dnf.py \
         --log-cli-level=INFO -s {posargs}
 
-[testenv:integration-but-with-cleantest]
+[testenv:integration-cleantest]
 description = Run integration tests using cleantest
 deps =
     cleantest==0.4.0-rc1

--- a/tox.ini
+++ b/tox.ini
@@ -93,3 +93,10 @@ deps =
     pytest
 commands =
     pytest -v --tb native --ignore={[vars]tst_dir}unit --log-cli-level=INFO -s {posargs}
+
+[testenv:integration-but-with-cleantest]
+description = Run integration tests using cleantest
+deps =
+    cleantest==0.4.0-rc1
+commands =
+    python3 -m unittest {toxinidir}/tests/integration/test_dnf.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
+
 [tox]
 skipsdist=True
 skip_missing_interpreters = True
@@ -11,7 +12,8 @@ tst_dir = {toxinidir}/tests/
 itst_dir = {toxinidir}/tests/integration
 lib_dir = {toxinidir}/lib/charms/operator_libs_linux/
 all_dir = {[vars]src_dir} {[vars]tst_dir} {[vars]lib_dir}
-lxd_name = ops-libs-test
+lxd_ubuntu = ops-libs-test-ubuntu
+lxd_centos = ops-libs-test-centos
 
 [testenv]
 setenv =
@@ -50,7 +52,7 @@ deps =
     pep8-naming
     isort
 commands =
-    # pflake8 wrapper suppports config from pyproject.toml
+    # pflake8 wrapper supports config from pyproject.toml
     pflake8 {[vars]all_dir}
     isort --check-only --diff {[vars]all_dir}
     black --check --diff {[vars]all_dir}
@@ -73,22 +75,32 @@ allowlist_externals =
     lxc
     bash
 commands =
-    # Create a LXC container with the relevant packages installed
-    bash -c 'lxc launch -qe ubuntu:focal {[vars]lxd_name} -c=user.user-data="$(<{[vars]itst_dir}/test_setup.yaml)"'
-    # Wait for the cloud-init process to finish
-    lxc exec {[vars]lxd_name} -- bash -c "cloud-init status -w >/dev/null 2>&1"
-    # Copy all the files needed for integration testing
-    lxc file push -qp {toxinidir}/tox.ini {[vars]lxd_name}/{[vars]lxd_name}/
-    lxc file push -qp {toxinidir}/pyproject.toml {[vars]lxd_name}/{[vars]lxd_name}/
-    lxc file push -qpr {toxinidir}/lib {[vars]lxd_name}/{[vars]lxd_name}/
-    lxc file push -qpr {[vars]tst_dir} {[vars]lxd_name}/{[vars]lxd_name}/
-    # Run the tests
-    lxc exec {[vars]lxd_name} -- tox -c /{[vars]lxd_name}/tox.ini -e integration-tests {posargs}
-commands_post =
-    -lxc stop {[vars]lxd_name}
+    # Create a LXD containers for Ubuntu and CentOS with necessary packages installed.
+    bash -c 'lxc launch -qe ubuntu:focal {[vars]lxd_ubuntu} -c=user.user-data="$(<{[vars]itst_dir}/test_setup.yaml)"'
+    bash -c 'lxc launch -qe images:centos/9-Stream/cloud {[vars]lxd_centos} -c=user.user-data="$(<{[vars]itst_dir}/test_setup.yaml)"'
 
-[testenv:integration-tests]
-description = Run integration tests
+    # Wait for the cloud-init process to finish in both Ubuntu and CentOS image.
+    lxc exec {[vars]lxd_ubuntu} -- bash -c "cloud-init status -w >/dev/null 2>&1"
+    lxc exec {[vars]lxd_centos} -- bash -c "cloud-init status -w >/dev/null 2>&1"
+
+    # Copy all the files needed for integration testing into instances.
+    lxc file push -qp {toxinidir}/tox.ini {[vars]lxd_ubuntu}/{[vars]lxd_ubuntu}/
+    lxc file push -qp {toxinidir}/pyproject.toml {[vars]lxd_ubuntu}/{[vars]lxd_ubuntu}/
+    lxc file push -qpr {toxinidir}/lib {[vars]lxd_ubuntu}/{[vars]lxd_ubuntu}/
+    lxc file push -qpr {[vars]tst_dir} {[vars]lxd_ubuntu}/{[vars]lxd_ubuntu}/
+    lxc file push -qp {toxinidir}/tox.ini {[vars]lxd_centos}/{[vars]lxd_centos}/
+    lxc file push -qp {toxinidir}/pyproject.toml {[vars]lxd_centos}/{[vars]lxd_centos}/
+    lxc file push -qpr {toxinidir}/lib {[vars]lxd_centos}/{[vars]lxd_centos}/
+    lxc file push -qpr {[vars]tst_dir} {[vars]lxd_centos}/{[vars]lxd_centos}/
+
+    # Run the tests.
+    lxc exec {[vars]lxd_ubuntu} -- tox -c /{[vars]lxd_ubuntu}/tox.ini -e integration-ubuntu {posargs}
+    lxc exec {[vars]lxd_centos} -- tox -c /{[vars]lxd_centos}/tox.ini -e integration-centos {posargs}
+commands_post =
+    -lxc stop {[vars]lxd_ubuntu} {[vars]lxd_centos}
+
+[testenv:integration-ubuntu]
+description = Run integration tests for Ubuntu instance.
 deps =
     pytest
 commands =
@@ -96,9 +108,9 @@ commands =
         --ignore={[vars]tst_dir}integration/test_dnf.py \
         --log-cli-level=INFO -s {posargs}
 
-[testenv:integration-cleantest]
-description = Run integration tests using cleantest
+[testenv:integration-centos]
+description = Run integration tests for CentOS instance.
 deps =
-    cleantest==0.4.0-rc1
+    pytest
 commands =
-    python3 -m unittest {toxinidir}/tests/integration/test_dnf.py
+    pytest -v --tb native --log-cli-level=INFO -s {[vars]tst_dir}integration/test_dnf.py {posargs}


### PR DESCRIPTION
## Description

This pull request aims to add a dnf charm library offering to the operator_libs_linux collection of charm libraries. The dnf library will be used for charms that need to support both Ubuntu and RPM-based distributions (CentOS, Alma, etc.), as well as charms just intended to be deployed to just RPM-based Juju units. It comes with the standard bells and whistles needed to interact with dnf from a simple Python interface.

## What still needs to be done

Documentation and registering the library on Charmhub. This pull request is mostly focused on just adding the initial code for a dnf charm library; do not want too many themes in the pull request review.

## Notes

* I updated the version of the `setup-lxd` GitHub Action to 0.1.0 instead of just using a commit hash. I also set the channel of LXD to 5.9/stable
* I am using the [cleantest](https://nuccitheboss.github.io/cleantest/) library to provide the test instances for the dnf charm library. This way the library can be tested inside a RPM-based environment on GitHub Actions.
* I added a separate tox env named `integration-but-with-cleantest` so that I did not mess with how the current integration tests are done. I added an extra step in the CI job for the new environment. 