### PR TITLE
build: update to use ruff/codespell

### DIFF
--- a/lib/charms/operator_libs_linux/v0/apt.py
+++ b/lib/charms/operator_libs_linux/v0/apt.py
@@ -78,7 +78,6 @@ Keys are constructed as `{repo_type}-{}-{release}` in order to uniquely identify
 Repositories can be added with explicit values through a Python constructor.
 
 Example:
-
 ```python
 repositories = apt.RepositoryMapping()
 
@@ -91,7 +90,6 @@ Alternatively, any valid `sources.list` line may be used to construct a new
 `DebianRepository`.
 
 Example:
-
 ```python
 repositories = apt.RepositoryMapping()
 
@@ -135,7 +133,7 @@ class Error(Exception):
     """Base class of most errors raised by this library."""
 
     def __repr__(self):
-        """String representation of Error."""
+        """Represent the Error."""
         return "<{}.{} {}>".format(type(self).__module__, type(self).__name__, self.args)
 
     @property
@@ -212,15 +210,15 @@ class DebianPackage:
         ) == (other._name, other._version.number)
 
     def __hash__(self):
-        """A basic hash so this class can be used in Mappings and dicts."""
+        """Return a hash of this package."""
         return hash((self._name, self._version.number))
 
     def __repr__(self):
-        """A representation of the package."""
+        """Represent the package."""
         return "<{}.{}: {}>".format(self.__module__, self.__class__.__name__, self.__dict__)
 
     def __str__(self):
-        """A human-readable representation of the package."""
+        """Return a human-readable representation of the package."""
         return "<{}: {}-{}.{} -- {}>".format(
             self.__class__.__name__,
             self._name,
@@ -267,7 +265,7 @@ class DebianPackage:
         )
 
     def _remove(self) -> None:
-        """Removes a package from the system. Implementation-specific."""
+        """Remove a package from the system. Implementation-specific."""
         return self._apt("remove", "{}={}".format(self.name, self.version))
 
     @property
@@ -276,7 +274,7 @@ class DebianPackage:
         return self._name
 
     def ensure(self, state: PackageState):
-        """Ensures that a package is in a given state.
+        """Ensure that a package is in a given state.
 
         Args:
           state: a `PackageState` to reconcile the package to
@@ -308,7 +306,7 @@ class DebianPackage:
 
     @state.setter
     def state(self, state: PackageState) -> None:
-        """Sets the package state to a given value.
+        """Set the package state to a given value.
 
         Args:
           state: a `PackageState` to reconcile the package to
@@ -527,11 +525,11 @@ class Version:
         self._epoch = epoch or ""
 
     def __repr__(self):
-        """A representation of the package."""
+        """Represent the package."""
         return "<{}.{}: {}>".format(self.__module__, self.__class__.__name__, self.__dict__)
 
     def __str__(self):
-        """A human-readable representation of the package."""
+        """Return human-readable representation of the package."""
         return "{}{}".format("{}:".format(self._epoch) if self._epoch else "", self._version)
 
     @property
@@ -732,6 +730,7 @@ def add_package(
     """Add a package or list of packages to the system.
 
     Args:
+        package_names: single package name, or list of package names
         name: the name(s) of the package(s)
         version: an (Optional) version as a string. Defaults to the latest known
         arch: an optional architecture for the package
@@ -788,7 +787,7 @@ def _add(
     version: Optional[str] = "",
     arch: Optional[str] = "",
 ) -> Tuple[Union[DebianPackage, str], bool]:
-    """Adds a package.
+    """Add a package to the system.
 
     Args:
         name: the name(s) of the package(s)
@@ -809,7 +808,7 @@ def _add(
 def remove_package(
     package_names: Union[str, List[str]]
 ) -> Union[DebianPackage, List[DebianPackage]]:
-    """Removes a package from the system.
+    """Remove package(s) from the system.
 
     Args:
         package_names: the name of a package
@@ -837,7 +836,7 @@ def remove_package(
 
 
 def update() -> None:
-    """Updates the apt cache via `apt-get update`."""
+    """Update the apt cache via `apt-get update`."""
     check_call(["apt-get", "update"], stderr=PIPE, stdout=PIPE)
 
 
@@ -966,7 +965,7 @@ class DebianRepository:
 
     @filename.setter
     def filename(self, fname: str) -> None:
-        """Sets the filename used when a repo is written back to diskself.
+        """Set the filename used when a repo is written back to disk.
 
         Args:
             fname: a filename to write the repository information to.
@@ -1148,7 +1147,7 @@ class DebianRepository:
 
     @staticmethod
     def _dearmor_gpg_key(key_asc: bytes) -> bytes:
-        """Converts a GPG key in the ASCII armor format to the binary format.
+        """Convert a GPG key in the ASCII armor format to the binary format.
 
         Args:
           key_asc: A GPG key in ASCII armor format.
@@ -1172,7 +1171,7 @@ class DebianRepository:
 
     @staticmethod
     def _write_apt_gpg_keyfile(key_name: str, key_material: bytes) -> None:
-        """Writes GPG key material into a file at a provided path.
+        """Write GPG key material into a file at a provided path.
 
         Args:
           key_name: A key name to use for a key file (could be a fingerprint)
@@ -1220,7 +1219,7 @@ class RepositoryMapping(Mapping):
         return len(self._repository_map)
 
     def __iter__(self) -> Iterable[DebianRepository]:
-        """Iterator magic method for RepositoryMapping."""
+        """Return iterator for RepositoryMapping."""
         return iter(self._repository_map.values())
 
     def __getitem__(self, repository_uri: str) -> DebianRepository:

--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -113,7 +113,7 @@ class SnapService:
         enabled: bool = False,
         active: bool = False,
         activators: List[str] = [],
-        **kwargs
+        **kwargs,
     ):
         self.daemon = daemon
         self.daemon_scope = kwargs.get("daemon-scope", None) or daemon_scope
@@ -122,7 +122,7 @@ class SnapService:
         self.activators = activators
 
     def as_dict(self) -> Dict:
-        """Returns instance representation as dict."""
+        """Return instance representation as dict."""
         return {
             "daemon": self.daemon,
             "daemon_scope": self.daemon_scope,
@@ -158,7 +158,7 @@ class Error(Exception):
     """Base class of most errors raised by this library."""
 
     def __repr__(self):
-        """String representation of the Error class."""
+        """Represent the Error class."""
         return "<{}.{} {}>".format(type(self).__module__, type(self).__name__, self.args)
 
     @property
@@ -176,7 +176,6 @@ class SnapAPIError(Error):
     """Raised when an HTTP API error occurs talking to the Snapd server."""
 
     def __init__(self, body: Dict, code: int, status: str, message: str):
-        """This shouldn't be instantiated directly."""
         super().__init__(message)  # Makes str(e) return message
         self.body = body
         self.code = code
@@ -184,7 +183,7 @@ class SnapAPIError(Error):
         self._message = message
 
     def __repr__(self):
-        """String representation of the SnapAPIError class."""
+        """Represent the SnapAPIError class."""
         return "APIError({!r}, {!r}, {!r}, {!r})".format(
             self.body, self.code, self.status, self._message
         )
@@ -245,15 +244,15 @@ class Snap(object):
         ) == (other._name, other._revision)
 
     def __hash__(self):
-        """A basic hash so this class can be used in Mappings and dicts."""
+        """Calculate a hash for this snap."""
         return hash((self._name, self._revision))
 
     def __repr__(self):
-        """A representation of the snap."""
+        """Represent the object such that it can be reconstructed."""
         return "<{}.{}: {}>".format(self.__module__, self.__class__.__name__, self.__dict__)
 
     def __str__(self):
-        """A human-readable representation of the snap."""
+        """Represent the snap object as a string."""
         return "<{}: {}-{}.{} -- {}>".format(
             self.__class__.__name__,
             self._name,
@@ -312,7 +311,7 @@ class Snap(object):
             raise SnapError("Could not {} for snap [{}]: {}".format(_cmd, self._name, e.stderr))
 
     def get(self, key) -> str:
-        """Gets a snap configuration value.
+        """Fetch a snap configuration value.
 
         Args:
             key: the key to retrieve
@@ -320,7 +319,7 @@ class Snap(object):
         return self._snap("get", [key]).strip()
 
     def set(self, config: Dict) -> str:
-        """Sets a snap configuration value.
+        """Set a snap configuration value.
 
         Args:
            config: a dictionary containing keys and values specifying the config to set.
@@ -330,7 +329,7 @@ class Snap(object):
         return self._snap("set", [*args])
 
     def unset(self, key) -> str:
-        """Unsets a snap configuration value.
+        """Unset a snap configuration value.
 
         Args:
             key: the key to unset
@@ -338,7 +337,7 @@ class Snap(object):
         return self._snap("unset", [key])
 
     def start(self, services: Optional[List[str]] = None, enable: Optional[bool] = False) -> None:
-        """Starts a snap's services.
+        """Start a snap's services.
 
         Args:
             services (list): (optional) list of individual snap services to start (otherwise all)
@@ -348,7 +347,7 @@ class Snap(object):
         self._snap_daemons(args, services)
 
     def stop(self, services: Optional[List[str]] = None, disable: Optional[bool] = False) -> None:
-        """Stops a snap's services.
+        """Stop a snap's services.
 
         Args:
             services (list): (optional) list of individual snap services to stop (otherwise all)
@@ -358,7 +357,7 @@ class Snap(object):
         self._snap_daemons(args, services)
 
     def logs(self, services: Optional[List[str]] = None, num_lines: Optional[int] = 10) -> str:
-        """Shows a snap services' logs.
+        """Fetch a snap services' logs.
 
         Args:
             services (list): (optional) list of individual snap services to show logs from
@@ -371,7 +370,7 @@ class Snap(object):
     def connect(
         self, plug: str, service: Optional[str] = None, slot: Optional[str] = None
     ) -> None:
-        """Connects a plug to a slot.
+        """Connect a plug to a slot.
 
         Args:
             plug (str): the plug to connect
@@ -455,7 +454,7 @@ class Snap(object):
         self._snap("refresh", args)
 
     def _remove(self) -> str:
-        """Removes a snap from the system."""
+        """Remove a snap from the system."""
         return self._snap("remove")
 
     @property
@@ -470,7 +469,7 @@ class Snap(object):
         channel: Optional[str] = "",
         cohort: Optional[str] = "",
     ):
-        """Ensures that a snap is in a given state.
+        """Ensure that a snap is in a given state.
 
         Args:
           state: a `SnapState` to reconcile to.
@@ -504,7 +503,7 @@ class Snap(object):
         self._state = state
 
     def _update_snap_apps(self) -> None:
-        """Updates a snap's apps after snap changes state."""
+        """Update a snap's apps after snap changes state."""
         try:
             self._apps = self._snap_client.get_installed_snap_apps(self._name)
         except SnapAPIError:
@@ -513,22 +512,22 @@ class Snap(object):
 
     @property
     def present(self) -> bool:
-        """Returns whether or not a snap is present."""
+        """Report whether or not a snap is present."""
         return self._state in (SnapState.Present, SnapState.Latest)
 
     @property
     def latest(self) -> bool:
-        """Returns whether the snap is the most recent version."""
+        """Report whether the snap is the most recent version."""
         return self._state is SnapState.Latest
 
     @property
     def state(self) -> SnapState:
-        """Returns the current snap state."""
+        """Report the current snap state."""
         return self._state
 
     @state.setter
     def state(self, state: SnapState) -> None:
-        """Sets the snap state to a given value.
+        """Set the snap state to a given value.
 
         Args:
           state: a `SnapState` to reconcile the snap to.
@@ -734,15 +733,15 @@ class SnapCache(Mapping):
             self._load_installed_snaps()
 
     def __contains__(self, key: str) -> bool:
-        """Magic method to ease checking if a given snap is in the cache."""
+        """Check if a given snap is in the cache."""
         return key in self._snap_map
 
     def __len__(self) -> int:
-        """Returns number of items in the snap cache."""
+        """Report number of items in the snap cache."""
         return len(self._snap_map)
 
     def __iter__(self) -> Iterable["Snap"]:
-        """Magic method to provide an iterator for the snap cache."""
+        """Provide iterator for the snap cache."""
         return iter(self._snap_map.values())
 
     def __getitem__(self, snap_name: str) -> Snap:
@@ -829,6 +828,7 @@ def add(
         channel: an (Optional) channel as a string. Defaults to 'latest'
         classic: an (Optional) boolean specifying whether it should be added with classic
             confinement. Default `False`
+        cohort: an (Optional) string specifying the snap cohort to use
 
     Raises:
         SnapError if some snaps failed to install or were not found.
@@ -845,7 +845,7 @@ def add(
 
 @_cache_init
 def remove(snap_names: Union[str, List[str]]) -> Union[Snap, List[Snap]]:
-    """Removes a snap from the system.
+    """Remove specified snap(s) from the system.
 
     Args:
         snap_names: the name or names of the snaps to install
@@ -868,14 +868,15 @@ def ensure(
     classic: Optional[bool] = False,
     cohort: Optional[str] = "",
 ) -> Union[Snap, List[Snap]]:
-    """Ensures a snap is in a given state to the system.
+    """Ensure specified snaps are in a given state on the system.
 
     Args:
-        name: the name(s) of the snaps to operate on
+        snap_names: the name(s) of the snaps to operate on
         state: a string representation of the desired state, from `SnapState`
         channel: an (Optional) channel as a string. Defaults to 'latest'
         classic: an (Optional) boolean specifying whether it should be added with classic
             confinement. Default `False`
+        cohort: an (Optional) string specifying the snap cohort to use
 
     Raises:
         SnapError if the snap is not in the cache.
@@ -915,9 +916,7 @@ def _wrap_snap_operations(
 
     if len(snaps["failed"]):
         raise SnapError(
-            "Failed to install or refresh snap(s): {}".format(
-                ", ".join([s for s in snaps["failed"]])
-            )
+            "Failed to install or refresh snap(s): {}".format(", ".join(list(snaps["failed"])))
         )
 
     return snaps["success"] if len(snaps["success"]) > 1 else snaps["success"][0]
@@ -964,7 +963,7 @@ def install_local(
 
 
 def _system_set(config_item: str, value: str) -> None:
-    """Helper for setting snap system config values.
+    """Set system snapd config values.
 
     Args:
         config_item: name of snap system setting. E.g. 'refresh.hold'

--- a/lib/charms/operator_libs_linux/v1/systemd.py
+++ b/lib/charms/operator_libs_linux/v1/systemd.py
@@ -64,17 +64,19 @@ LIBPATCH = 1
 
 
 class SystemdError(Exception):
+    """Custom exception for SystemD related errors."""
+
     pass
 
 
 def _popen_kwargs():
-    return dict(
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        bufsize=1,
-        universal_newlines=True,
-        encoding="utf-8",
-    )
+    return {
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.STDOUT,
+        "bufsize": 1,
+        "universal_newlines": True,
+        "encoding": "utf-8",
+    }
 
 
 def _systemctl(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,32 +5,38 @@ branch = true
 [tool.coverage.report]
 show_missing = true
 
-# Formatting tools configuration
-[tool.black]
-line-length = 99
-target-version = ["py35"]
-
-[tool.isort]
-profile = "black"
-
-# Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
-max-complexity = 14
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore W503, E501 because using black creates errors with this
-# Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107", "D412"]
-# D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
-docstring-convention = "google"
-# Check for properly formatted copyright header in each file
-copyright-check = "True"
-copyright-author = "Canonical Ltd."
-copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
-
 [tool.pytest.ini_options]
 minversion = "6.0"
 log_cli_level = "INFO"
+
+# Formatting tools configuration
+[tool.black]
+line-length = 99
+target-version = ["py38"]
+
+# Linting tools configuration
+[tool.ruff]
+line-length = 99
+select = ["E", "W", "F", "C", "N", "D", "I001"]
+extend-ignore = [
+    "D203",
+    "D204",
+    "D213",
+    "D215",
+    "D400",
+    "D404",
+    "D406",
+    "D407",
+    "D408",
+    "D409",
+    "D413",
+]
+ignore = ["E501", "D107"]
+extend-exclude = ["__pycache__", "*.egg_info"]
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
+
+[tool.ruff.mccabe]
+max-complexity = 14
+
+[tool.codespell]
+skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.vscode,.coverage"

--- a/tests/integration/test_snap.py
+++ b/tests/integration/test_snap.py
@@ -81,7 +81,7 @@ def test_unset_key_raises_snap_error():
     else:
         logger.error("Getting an unset key should result in a SnapError.")
 
-    # We can make the above work w/ abitrary config.
+    # We can make the above work w/ arbitrary config.
     lxd.set({key: "true"})
     assert lxd.get(key) == "true"
 

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -498,7 +498,7 @@ class TestSnapBareMethods(unittest.TestCase):
                 universal_newlines=True,
             )
         except AssertionError:
-            # The ordering of this call can be unpredictable across Python verisons.
+            # The ordering of this call can be unpredictable across Python versions.
             # Unfortunately, the methods available to introspect the call list have also
             # changed, so we do this, which is a little clunky.
             mock_subprocess.assert_called_with(

--- a/tests/unit/test_systemd.py
+++ b/tests/unit/test_systemd.py
@@ -9,10 +9,10 @@ from charms.operator_libs_linux.v1 import systemd
 
 
 def with_mock_subp(func):
-    """Decorator that sets up a Popen mock.
+    """Set up a Popen mock.
 
     Any function that uses this decorator should take a function as an argument. When
-    called wtih a series of return codes, that function will mock out subprocess.Popen,
+    called with a series of return codes, that function will mock out subprocess.Popen,
     and set it to return those error codes, in order.
 
     The function returns the mock Popen object, so that routines such as
@@ -106,7 +106,7 @@ class TestSystemD(unittest.TestCase):
 
     @with_mock_subp
     def test_service_reload(self, make_mock):
-        # We reload succesfully.
+        # We reload successfully.
         mockp, kw = make_mock([0])
         reloaded = systemd.service_reload("mysql")
         mockp.assert_called_with(["systemctl", "reload", "mysql"], **kw)

--- a/tox.ini
+++ b/tox.ini
@@ -18,43 +18,31 @@ lxd_centos = ops-libs-test-centos
 [testenv]
 setenv =
   PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_dir}
-  PYTHONBREAKPOINT=ipdb.set_trace
+  PYTHONBREAKPOINT=pdb.set_trace
   PY_COLORS=1
 passenv =
   PYTHONPATH
-  HOME
-  PATH
   CHARM_BUILD_DIR
   MODEL_SETTINGS
-  HTTP_PROXY
-  HTTPS_PROXY
-  NO_PROXY
 
 [testenv:fmt]
 description = Apply coding style standards to code
 deps =
     black
-    isort
+    ruff
 commands =
-    isort {[vars]all_dir}
+    ruff --fix {[vars]all_dir}
     black {[vars]all_dir}
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
     black
-    flake8==4.0.1
-    flake8-docstrings
-    flake8-copyright
-    flake8-builtins
-    mypy
-    pyproject-flake8
-    pep8-naming
-    isort
+    ruff
+    codespell
 commands =
-    # pflake8 wrapper supports config from pyproject.toml
-    pflake8 {[vars]all_dir}
-    isort --check-only --diff {[vars]all_dir}
+    codespell {toxinidir}
+    ruff {[vars]all_dir}
     black --check --diff {[vars]all_dir}
 
 [testenv:unit]
@@ -65,8 +53,12 @@ deps =
     -r{toxinidir}/requirements.txt
     pyfakefs==4.4.0
 commands =
-	coverage run --source={[vars]lib_dir} \
-        -m pytest --ignore={[vars]tst_dir}integration -v --tb native {posargs}
+    coverage run --source={[vars]lib_dir} \
+                 -m pytest \
+                 --ignore={[vars]tst_dir}integration \
+                 --tb native \
+                 -v \
+                 {posargs}
     coverage report
 
 [testenv:integration]
@@ -104,13 +96,22 @@ description = Run integration tests for Ubuntu instance.
 deps =
     pytest
 commands =
-    pytest -v --tb native --ignore={[vars]tst_dir}unit \
-        --ignore={[vars]tst_dir}integration/test_dnf.py \
-        --log-cli-level=INFO -s {posargs}
+    pytest --ignore={[vars]tst_dir}unit \
+           --ignore={[vars]tst_dir}integration/test_dnf.py \
+           --log-cli-level=INFO \
+           --tb native \
+           -v \
+           -s \
+           {posargs}
 
 [testenv:integration-centos]
 description = Run integration tests for CentOS instance.
 deps =
     pytest
 commands =
-    pytest -v --tb native --log-cli-level=INFO -s {[vars]tst_dir}integration/test_dnf.py {posargs}
+    pytest --log-cli-level=INFO \
+           --tb native \
+           -v \
+           -s \
+           {[vars]tst_dir}integration/test_dnf.py \
+           {posargs}


### PR DESCRIPTION
There looks like there are lots of changes here, but the key is:

- Update from black/isort -> black/ruff
- Introduce codespell

Then there are a bunch of changes to docstrings and spellings to conform to ruff's rules. Main change is making first line of docstrings use the imperative mood.

Fixes #77 