### PR TITLE
ci: restructure CI; include release charm and lib action

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,10 +1,12 @@
-name: Operator Libs CI
-on: [pull_request, push]
+name: Build/Test
+
+on:
+  workflow_call:
 
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -14,7 +16,7 @@ jobs:
         run: tox -e lint
   unit-test:
     name: Unit tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ["3.8", "3.10"]
@@ -31,7 +33,7 @@ jobs:
         run: tox -e unit
   integration-test:
     name: Integration tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,0 +1,11 @@
+name: Tests
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    uses: ./.github/workflows/build-and-test.yaml

--- a/.github/workflows/release-libs.yaml
+++ b/.github/workflows/release-libs.yaml
@@ -1,0 +1,21 @@
+name: Release Libraries
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-libs:
+    name: Release any bumped library
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Release any bumped charm library
+        uses: canonical/charming-actions/release-libraries@2.2.3
+        with:
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,40 @@
+name: Release to latest/edge
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "src/**"
+      - "metadata.yaml"
+      - "requirements.txt"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    uses: ./.github/workflows/build-and-test.yaml
+    secrets:
+      CHARMHUB_TOKEN: "${{ secrets.CHARMHUB_TOKEN }}"
+
+  release-to-charmhub:
+    name: Release to CharmHub
+    needs:
+      - test
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@2.2.3
+        id: channel
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@2.2.3
+        with:
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          channel: "${{ steps.channel.outputs.name }}"

--- a/lib/charms/operator_libs_linux/v0/apt.py
+++ b/lib/charms/operator_libs_linux/v0/apt.py
@@ -124,7 +124,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 10
+LIBPATCH = 11
 
 
 VALID_SOURCE_TYPES = ("deb", "deb-src")

--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -83,7 +83,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 8
 
 
 # Regex to locate 7-bit C1 ANSI sequences

--- a/lib/charms/operator_libs_linux/v1/systemd.py
+++ b/lib/charms/operator_libs_linux/v1/systemd.py
@@ -60,7 +60,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 
 class SystemdError(Exception):


### PR DESCRIPTION
This PR makes a few key changes to our CI:

- Use `ubuntu-22.04` everywhere rather than `ubuntu-20.04`
- Use concurrency controls to prevent unnecessary runs
- Don't duplicate runs for PRs (previously we triggered on `push` and `pull-request` without constraint)
- Release charm to edge on merge to main, and a relevant path was updated
- Release charm libs when changed automatically

Fixes #71 