### PR TITLE
feat: add forever hold to snap refresh.hold

### DIFF
--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -976,15 +976,21 @@ def _system_set(config_item: str, value: str) -> None:
         raise SnapError("Failed setting system config '{}' to '{}'".format(config_item, value))
 
 
-def hold_refresh(days: int = 90) -> bool:
+def hold_refresh(days: int = 90, forever: bool = False) -> bool:
     """Set the system-wide snap refresh hold.
 
     Args:
         days: number of days to hold system refreshes for. Maximum 90. Set to zero to remove hold.
+        forever: if set  to True, will set a hold forever.
     """
+    if not isinstance(forever, bool):
+        raise ValueError("forever must be a boolean")
     # Currently the snap daemon can only hold for a maximum of 90 days
-    if not isinstance(days, int) or days > 90:
+    elif not isinstance(days, int) or days > 90:
         raise ValueError("days must be an int between 1 and 90")
+    elif forever:
+        _system_set("refresh.hold", "forever")
+        logger.info("Set system-wide snap refresh hold to: forever")
     elif days == 0:
         _system_set("refresh.hold", "")
         logger.info("Removed system-wide snap refresh hold")

--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -981,20 +981,22 @@ def hold_refresh(days: int = 90, forever: bool = False) -> bool:
 
     Args:
         days: number of days to hold system refreshes for. Maximum 90. Set to zero to remove hold.
-        forever: if set  to True, will set a hold forever.
+        forever: if True, will set a hold forever.
     """
     if not isinstance(forever, bool):
-        raise ValueError("forever must be a boolean")
-    # Currently the snap daemon can only hold for a maximum of 90 days
-    elif not isinstance(days, int) or days > 90:
-        raise ValueError("days must be an int between 1 and 90")
-    elif forever:
+        raise TypeError("forever must be a bool")
+    if not isinstance(days, int):
+        raise TypeError("days must be an int")
+    if forever:
         _system_set("refresh.hold", "forever")
         logger.info("Set system-wide snap refresh hold to: forever")
     elif days == 0:
         _system_set("refresh.hold", "")
         logger.info("Removed system-wide snap refresh hold")
     else:
+        # Currently the snap daemon can only hold for a maximum of 90 days
+        if not 1 <= days <= 90:
+            raise ValueError("days must be between 1 and 90")
         # Add the number of days to current time
         target_date = datetime.now(timezone.utc).astimezone() + timedelta(days=days)
         # Format for the correct datetime format

--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -83,7 +83,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 9
 
 
 # Regex to locate 7-bit C1 ANSI sequences

--- a/tests/integration/test_snap.py
+++ b/tests/integration/test_snap.py
@@ -167,6 +167,12 @@ def test_hold_refresh():
     assert f"hold: {hold_date}" in result.decode()
 
 
+def test_forever_hold_refresh():
+    snap.hold_refresh(forever=True)
+    result = check_output(["snap", "refresh", "--time"])
+    assert "hold: 2315-06-30" in result.decode()
+
+
 def test_reset_hold_refresh():
     snap.hold_refresh()
     snap.hold_refresh(0)

--- a/tests/integration/test_snap.py
+++ b/tests/integration/test_snap.py
@@ -169,8 +169,8 @@ def test_hold_refresh():
 
 def test_forever_hold_refresh():
     snap.hold_refresh(forever=True)
-    result = check_output(["snap", "refresh", "--time"])
-    assert "hold: 2315-06-30" in result.decode()
+    result = check_output(["snap", "get", "system", "refresh.hold"])
+    assert "forever" in result.decode()
 
 
 def test_reset_hold_refresh():

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -534,11 +534,26 @@ class TestSnapBareMethods(unittest.TestCase):
         except ValueError as e:
             self.assertEqual(str(e), "days must be an int between 1 and 90")
 
+    def test_hold_refresh_invalid_non_bool(self):
+        try:
+            snap.hold_refresh(forever="foobar")
+        except ValueError as e:
+            self.assertEqual(str(e), "forever must be a boolean")
+
     @patch("charms.operator_libs_linux.v1.snap.subprocess.check_call")
     def test_hold_refresh_reset(self, mock_subprocess):
         snap.hold_refresh(days=0)
         mock_subprocess.assert_called_with(
             ["snap", "set", "system", "refresh.hold="],
+            universal_newlines=True,
+        )
+
+    @patch("charms.operator_libs_linux.v1.snap.subprocess.check_call")
+    def test_hold_refresh_forever(self, mock_subprocess):
+        snap.hold_refresh(forever=True)
+
+        mock_subprocess.assert_called_with(
+            ["snap", "set", "system", "refresh.hold=forever"],
             universal_newlines=True,
         )
 

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -523,22 +523,16 @@ class TestSnapBareMethods(unittest.TestCase):
             self.assertEqual(str(e), "Failed setting system config 'refresh.hold' to 'foobar'")
 
     def test_hold_refresh_invalid_too_high(self):
-        try:
+        with self.assertRaises(ValueError):
             snap.hold_refresh(days=120)
-        except ValueError as e:
-            self.assertEqual(str(e), "days must be an int between 1 and 90")
 
     def test_hold_refresh_invalid_non_int(self):
-        try:
+        with self.assertRaises(TypeError):
             snap.hold_refresh(days="foobar")
-        except ValueError as e:
-            self.assertEqual(str(e), "days must be an int between 1 and 90")
 
     def test_hold_refresh_invalid_non_bool(self):
-        try:
+        with self.assertRaises(TypeError):
             snap.hold_refresh(forever="foobar")
-        except ValueError as e:
-            self.assertEqual(str(e), "forever must be a boolean")
 
     @patch("charms.operator_libs_linux.v1.snap.subprocess.check_call")
     def test_hold_refresh_reset(self, mock_subprocess):

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -517,10 +517,8 @@ class TestSnapBareMethods(unittest.TestCase):
     @patch("charms.operator_libs_linux.v1.snap.subprocess.check_call")
     def test_system_set_fail(self, mock_subprocess):
         mock_subprocess.side_effect = CalledProcessError(1, "foobar")
-        try:
+        with self.assertRaises(snap.SnapError):
             snap._system_set("refresh.hold", "foobar")
-        except snap.SnapError as e:
-            self.assertEqual(str(e), "Failed setting system config 'refresh.hold' to 'foobar'")
 
     def test_hold_refresh_invalid_too_high(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Based on the feedback on #80, adds an option to hold the refresh of snaps forever.