### PR TITLE
Do not set a `--channel` arg if it's not truthy

### DIFF
--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -83,7 +83,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 9
+LIBPATCH = 10
 
 
 # Regex to locate 7-bit C1 ANSI sequences
@@ -439,8 +439,9 @@ class Snap(object):
           cohort: optionally, specify a cohort.
           leave_cohort: leave the current cohort.
         """
-        channel = '--channel="{}"'.format(channel) if channel else ""
-        args = [channel]
+        args = []
+        if channel:
+            args.append('--channel="{}"'.format(channel))
 
         if not cohort:
             cohort = self._cohort


### PR DESCRIPTION
If an empty string is passed as as the channel during refreshing (ala `'snap refresh foo --channel="{}"'.format("")`, it simply parses out to an empty string.

This makes snap/subprocess bomb, because `["snap", "refresh", "foo", ""]` gives a pleasant result, like:

```
  File "./src/charm.py", line 181, in on_install                                                                         
    self.snap.ensure(state=snap.SnapState.Latest)                                                                        
  File "/var/lib/juju/agents/unit-grafana-agent-12/charm/lib/charms/operator_libs_linux/v1/snap.py", line 504, in ensure 
    self._refresh(channel, cohort)                                                                                       
  File "/var/lib/juju/agents/unit-grafana-agent-12/charm/lib/charms/operator_libs_linux/v1/snap.py", line 458, in _refresh
    self._snap("refresh", args)                                                                                          
  File "/var/lib/juju/agents/unit-grafana-agent-12/charm/lib/charms/operator_libs_linux/v1/snap.py", line 284, in _snap  
    raise SnapError( 
subprocess.CalledProcessError: Command '['snap', 'refresh', 'grafana-agent', '']' returned non-zero exit status 1. 
```

Build `--channel` as part of the arglist like everything else, so empty strings don't sneak through
