### PR TITLE
is-failed function for systemd services

### DIFF
--- a/lib/charms/operator_libs_linux/v1/systemd.py
+++ b/lib/charms/operator_libs_linux/v1/systemd.py
@@ -111,16 +111,16 @@ def _systemctl(
 
     proc.wait()
 
-    if sub_cmd == "is-active":
-        # If we are just checking whether a service is running, return True/False, rather
-        # than raising an error.
-        if proc.returncode < 1:
-            return True
-        if proc.returncode == 3:  # Code returned when service is not active.
-            return False
-
     if proc.returncode < 1:
         return True
+
+    # If we are just checking whether a service is running, return True/False, rather
+    # than raising an error.
+    if sub_cmd == "is-active" and proc.returncode == 3:  # Code returned when service not active.
+        return False
+
+    if sub_cmd == "is-failed":
+        return False
 
     raise SystemdError(
         "Could not {}{}: systemd output: {}".format(
@@ -136,6 +136,15 @@ def service_running(service_name: str) -> bool:
         service_name: the name of the service to check
     """
     return _systemctl("is-active", service_name, quiet=True)
+
+
+def service_failed(service_name: str) -> bool:
+    """Determine whether a system service has failed.
+
+    Args:
+        service_name: the name of the service to check
+    """
+    return _systemctl("is-failed", service_name, quiet=True)
 
 
 def service_start(service_name: str) -> bool:

--- a/tests/integration/test_systemd.py
+++ b/tests/integration/test_systemd.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
+
+
 import logging
 from subprocess import check_output
 

--- a/tests/integration/test_systemd.py
+++ b/tests/integration/test_systemd.py
@@ -22,27 +22,27 @@ from charms.operator_libs_linux.v1.systemd import (
 logger = logging.getLogger(__name__)
 
 
-def create_service(name: str, start_command: str):
-    """Create a custom service."""
-    content = f"""[Unit]
-    Description=Test Service
-    After=multi-user.target
-
-    [Service]
-    ExecStart=/usr/bin/bash -c "{start_command}"
-    Type=simple
-
-    [Install]
-    WantedBy=multi-user.target
-    """
-
-    with open(f"/etc/systemd/system/{name}", "w+") as f:
-        f.writelines([f"{line.strip()}\n" for line in content.split("\n")])
-
-    service_restart(name)
-
-
 def test_service():
+
+    def create_service(name: str, start_command: str):
+        """Create a custom service."""
+        content = f"""[Unit]
+        Description=Test Service
+        After=multi-user.target
+    
+        [Service]
+        ExecStart=/usr/bin/bash -c "{start_command}"
+        Type=simple
+    
+        [Install]
+        WantedBy=multi-user.target
+        """
+
+        with open(f"/etc/systemd/system/{name}", "w+") as f:
+            f.writelines([f"{line.strip()}\n" for line in content.split("\n")])
+
+        service_restart(name)
+
     # Cron is pre-installed in the lxc images we are using.
     assert service_running("cron")
     # Foo is made up, and should not be running.

--- a/tests/unit/test_systemd.py
+++ b/tests/unit/test_systemd.py
@@ -72,6 +72,18 @@ class TestSystemD(unittest.TestCase):
         self.assertFalse(is_running)
 
     @with_mock_subp
+    def test_service_failed(self, make_mock):
+        mockp, kw = make_mock([0, 1])
+
+        is_failed = systemd.service_failed("mysql")
+        mockp.assert_called_with(["systemctl", "is-failed", "mysql", "--quiet"], **kw)
+        self.assertTrue(is_failed)
+
+        is_failed = systemd.service_failed("mysql")
+        mockp.assert_called_with(["systemctl", "is-failed", "mysql", "--quiet"], **kw)
+        self.assertFalse(is_failed)
+
+    @with_mock_subp
     def test_service_start(self, make_mock):
         mockp, kw = make_mock([0, 1])
 


### PR DESCRIPTION
### Context:
When dealing with services, it is sometimes not enough to only know if a service is running or not, it is useful to know if the said service is in a failed state. 
This PR adds the `is-failed` status check.