### PR TITLE
feat: install snap by revision

### DIFF
--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -222,7 +222,7 @@ class Snap(object):
         name,
         state: SnapState,
         channel: str,
-        revision: str,
+        revision: int,
         confinement: str,
         apps: Optional[List[Dict[str, str]]] = None,
         cohort: Optional[str] = "",
@@ -424,7 +424,10 @@ class Snap(object):
         self._snap_daemons(args, services)
 
     def _install(
-        self, channel: Optional[str] = "", cohort: Optional[str] = "", revision: Optional[str] = ""
+        self,
+        channel: Optional[str] = "",
+        cohort: Optional[str] = "",
+        revision: Optional[int] = None,
     ) -> None:
         """Add a snap to the system.
 
@@ -451,7 +454,7 @@ class Snap(object):
         self,
         channel: Optional[str] = "",
         cohort: Optional[str] = "",
-        revision: Optional[str] = "",
+        revision: Optional[int] = None,
         leave_cohort: Optional[bool] = False,
     ) -> None:
         """Refresh a snap.
@@ -495,7 +498,7 @@ class Snap(object):
         classic: Optional[bool] = False,
         channel: Optional[str] = "",
         cohort: Optional[str] = "",
-        revision: Optional[str] = "",
+        revision: Optional[int] = None,
     ):
         """Ensure that a snap is in a given state.
 
@@ -569,7 +572,7 @@ class Snap(object):
         self._state = state
 
     @property
-    def revision(self) -> str:
+    def revision(self) -> int:
         """Returns the revision for a snap."""
         return self._revision
 
@@ -822,7 +825,7 @@ class SnapCache(Mapping):
                 name=i["name"],
                 state=SnapState.Latest,
                 channel=i["channel"],
-                revision=i["revision"],
+                revision=int(i["revision"]),
                 confinement=i["confinement"],
                 apps=i.get("apps", None),
             )
@@ -840,7 +843,7 @@ class SnapCache(Mapping):
             name=info["name"],
             state=SnapState.Available,
             channel=info["channel"],
-            revision=info["revision"],
+            revision=int(info["revision"]),
             confinement=info["confinement"],
             apps=None,
         )

--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -83,7 +83,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 11
+LIBPATCH = 12
 
 
 # Regex to locate 7-bit C1 ANSI sequences
@@ -423,12 +423,15 @@ class Snap(object):
         args = ["restart", "--reload"] if reload else ["restart"]
         self._snap_daemons(args, services)
 
-    def _install(self, channel: Optional[str] = "", cohort: Optional[str] = "") -> None:
+    def _install(
+        self, channel: Optional[str] = "", cohort: Optional[str] = "", revision: Optional[str] = ""
+    ) -> None:
         """Add a snap to the system.
 
         Args:
           channel: the channel to install from
           cohort: optional, the key of a cohort that this snap belongs to
+          revision: optional, the revision of the snap to install
         """
         cohort = cohort or self._cohort
 
@@ -437,6 +440,8 @@ class Snap(object):
             args.append("--classic")
         if channel:
             args.append('--channel="{}"'.format(channel))
+        if revision:
+            args.append('--revision="{}"'.format(revision))
         if cohort:
             args.append('--cohort="{}"'.format(cohort))
 
@@ -446,6 +451,7 @@ class Snap(object):
         self,
         channel: Optional[str] = "",
         cohort: Optional[str] = "",
+        revision: Optional[str] = "",
         leave_cohort: Optional[bool] = False,
     ) -> None:
         """Refresh a snap.
@@ -453,11 +459,15 @@ class Snap(object):
         Args:
           channel: the channel to install from
           cohort: optionally, specify a cohort.
+          revision: optionally, specify the revision of the snap to refresh
           leave_cohort: leave the current cohort.
         """
         args = []
         if channel:
             args.append('--channel="{}"'.format(channel))
+
+        if revision:
+            args.append('--revision="{}"'.format(revision))
 
         if not cohort:
             cohort = self._cohort
@@ -485,6 +495,7 @@ class Snap(object):
         classic: Optional[bool] = False,
         channel: Optional[str] = "",
         cohort: Optional[str] = "",
+        revision: Optional[str] = "",
     ):
         """Ensure that a snap is in a given state.
 
@@ -493,6 +504,7 @@ class Snap(object):
           classic: an (Optional) boolean indicating whether classic confinement should be used
           channel: the channel to install from
           cohort: optional. Specify the key of a snap cohort.
+          revision: optional. the revision of the snap to install/refresh
 
         Raises:
           SnapError if an error is encountered
@@ -511,10 +523,10 @@ class Snap(object):
             # We are installing or refreshing a snap.
             if self._state not in (SnapState.Present, SnapState.Latest):
                 # The snap is not installed, so we install it.
-                self._install(channel, cohort)
+                self._install(channel, cohort, revision)
             else:
                 # The snap is installed, but we are changing it (e.g., switching channels).
-                self._refresh(channel, cohort)
+                self._refresh(channel, cohort, revision)
 
         self._update_snap_apps()
         self._state = state

--- a/tests/integration/test_snap.py
+++ b/tests/integration/test_snap.py
@@ -5,7 +5,7 @@
 
 import logging
 from datetime import datetime, timedelta
-from subprocess import CalledProcessError, check_output
+from subprocess import CalledProcessError, check_output, run
 
 import pytest
 from charms.operator_libs_linux.v1 import snap
@@ -114,13 +114,18 @@ def test_snap_ensure_revision():
     assert get_command_path("juju") == "/snap/bin/juju"
     assert juju.revision == "1"
 
-    snap_info_juju = subprocess.run(
-        ["snap", "info", "juju"],
-        capture_output=True,
-        encoding="utf-8",
-    ).stdout.strip().split("\n")
+    snap_info_juju = (
+        run(
+            ["snap", "info", "juju"],
+            capture_output=True,
+            encoding="utf-8",
+        )
+        .stdout.strip()
+        .split("\n")
+    )
     assert "installed:" in snap_info_juju[-1]
     assert "(1)" in snap_info_juju[-1]
+
 
 def test_snap_start():
     cache = snap.SnapCache()

--- a/tests/integration/test_snap.py
+++ b/tests/integration/test_snap.py
@@ -109,10 +109,11 @@ def test_snap_ensure_revision():
     juju.ensure(snap.SnapState.Available)
     assert get_command_path("juju") == ""
 
-    # Install the snap with a specific revision
+    # Install the snap with the revision of latest/edge
     snap_info_juju = run(
         ["snap", "info", "juju"], capture_output=True, encoding="utf-8"
     ).stdout.split("\n")
+
     edge_revision = None
     for line in snap_info_juju:
         match = re.search(r"latest/edge.*\((\d+)\)", line)
@@ -120,25 +121,25 @@ def test_snap_ensure_revision():
         if match:
             edge_revision = int(match.group(1))
             break
-
     assert edge_revision is not None
 
     juju.ensure(snap.SnapState.Present, revision=edge_revision)
 
     assert get_command_path("juju") == "/snap/bin/juju"
-    assert juju.revision == edge_revision
 
-    snap_info_juju = (
-        run(
-            ["snap", "info", "juju"],
-            capture_output=True,
-            encoding="utf-8",
-        )
-        .stdout.strip()
-        .split("\n")
-    )
-    assert "installed:" in snap_info_juju[-1]
-    assert "({})".format(edge_revision) in snap_info_juju[-1]
+    snap_info_juju = run(
+        ["snap", "info", "juju"],
+        capture_output=True,
+        encoding="utf-8",
+    ).stdout.strip()
+
+    assert "installed" in snap_info_juju
+    for line in snap_info_juju.split("\n"):
+        if "installed" in line:
+            match = re.search(r"installed.*\((\d+)\)", line)
+
+            assert match is not None
+            assert int(match.group(1)) == edge_revision
 
 
 def test_snap_start():

--- a/tests/integration/test_snap.py
+++ b/tests/integration/test_snap.py
@@ -101,6 +101,27 @@ def test_new_snap_ensure():
     vlc.ensure(snap.SnapState.Latest, channel="edge")
 
 
+def test_snap_ensure_revision():
+    juju = snap.SnapCache()["juju"]
+
+    # Verify that the snap is not installed
+    juju.ensure(snap.SnapState.Available)
+    assert get_command_path("juju") == ""
+
+    # Install the snap with a specific revision
+    juju.ensure(snap.SnapState.Present, revision=1)
+
+    assert get_command_path("juju") == "/snap/bin/juju"
+    assert juju.revision == "1"
+
+    snap_info_juju = subprocess.run(
+        ["snap", "info", "juju"],
+        capture_output=True,
+        encoding="utf-8",
+    ).stdout.strip().split("\n")
+    assert "installed:" in snap_info_juju[-1]
+    assert "(1)" in snap_info_juju[-1]
+
 def test_snap_start():
     cache = snap.SnapCache()
     kp = cache["kube-proxy"]

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -480,8 +480,7 @@ class TestSnapBareMethods(unittest.TestCase):
 
         baz = snap.add("curl", classic=True, revision=123)
         mock_subprocess.assert_called_with(
-            ["snap", "install", "curl", "--classic", '--revision="123"'],
-            universal_newlines=True
+            ["snap", "install", "curl", "--classic", '--revision="123"'], universal_newlines=True
         )
         self.assertTrue(baz.present)
 

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -472,11 +472,18 @@ class TestSnapBareMethods(unittest.TestCase):
             ["snap", "install", "curl", "--classic", '--channel="latest"'],
             universal_newlines=True,
         )
-        self.assertEqual(foo.present, True)
+        self.assertTrue(foo.present)
 
         bar = snap.remove("curl")
         mock_subprocess.assert_called_with(["snap", "remove", "curl"], universal_newlines=True)
-        self.assertEqual(bar.present, False)
+        self.assertFalse(bar.present)
+
+        baz = snap.add("curl", classic=True, revision=123)
+        mock_subprocess.assert_called_with(
+            ["snap", "install", "curl", "--classic", '--revision="123"'],
+            universal_newlines=True
+        )
+        self.assertTrue(baz.present)
 
     @patch("charms.operator_libs_linux.v1.snap.subprocess")
     def test_cohort(self, mock_subprocess):
@@ -514,11 +521,18 @@ class TestSnapBareMethods(unittest.TestCase):
             ["snap", "install", "curl", "--classic", '--channel="latest/test"'],
             universal_newlines=True,
         )
-        self.assertEqual(foo.present, True)
+        self.assertTrue(foo.present)
 
         bar = snap.ensure("curl", "absent")
         mock_subprocess.assert_called_with(["snap", "remove", "curl"], universal_newlines=True)
-        self.assertEqual(bar.present, False)
+        self.assertFalse(bar.present)
+
+        baz = snap.ensure("curl", "present", classic=True, revision=123)
+        mock_subprocess.assert_called_with(
+            ["snap", "install", "curl", "--classic", '--revision="123"'],
+            universal_newlines=True,
+        )
+        self.assertTrue(baz.present)
 
     @patch("charms.operator_libs_linux.v1.snap.subprocess.check_output")
     def test_raises_snap_not_found_error(self, mock_subprocess):

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -223,7 +223,7 @@ class TestSnapCache(unittest.TestCase):
         self.assertEqual(result.state, snap.SnapState.Available)
         self.assertEqual(result.channel, "stable")
         self.assertEqual(result.confinement, "strict")
-        self.assertEqual(result.revision, "233")
+        self.assertEqual(result.revision, 233)
 
     @patch("os.path.isfile")
     def test_can_load_installed_snap_info(self, mock_exists):
@@ -240,7 +240,7 @@ class TestSnapCache(unittest.TestCase):
         self.assertEqual(s["charmcraft"].state, snap.SnapState.Latest)
         self.assertEqual(s["charmcraft"].channel, "latest/stable")
         self.assertEqual(s["charmcraft"].confinement, "classic")
-        self.assertEqual(s["charmcraft"].revision, "603")
+        self.assertEqual(s["charmcraft"].revision, 603)
 
     @patch("os.path.isfile")
     def test_raises_error_if_snap_not_running(self, mock_exists):
@@ -284,6 +284,11 @@ class TestSnapCache(unittest.TestCase):
 
         foo.state = snap.SnapState.Absent
         mock_subprocess.assert_called_with(["snap", "remove", "foo"], universal_newlines=True)
+
+        foo.ensure(snap.SnapState.Latest, revision=123)
+        mock_subprocess.assert_called_with(
+            ["snap", "install", "foo", "--classic", '--revision="123"'], universal_newlines=True
+        )
 
     @patch("charms.operator_libs_linux.v1.snap.subprocess.run")
     def test_can_run_snap_daemon_commands(self, mock_subprocess):


### PR DESCRIPTION
## Issue
We are now able to install snaps by revisions, but the snap charm library does not yet support this flag.

We would like to add support for the `--revision` flag so that we can pin our snap versions in charms.

## Solution
Add optional kwarg `revision` to the `ensure`, `_install` and `_refresh` methods of Snap in the snap charm lib 