### PR TITLE
update canonical/setup-lxd to v0.1.1

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: canonical/setup-lxd@v0.1.1
         with:
-          channel: 5.9/stable
+          channel: 5.0/stable
       - name: Install dependencies
         run: python -m pip install tox
       - name: Run integration tests

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: canonical/setup-lxd@v0.1.0
+      - uses: canonical/setup-lxd@v0.1.1
         with:
           channel: 5.9/stable
       - name: Install dependencies


### PR DESCRIPTION
There is a bug in canonical/setup-lxd@v0.1.0 where the `channel` input is ignored. This has been fixed in v0.1.1. See https://github.com/canonical/setup-lxd/pull/8