### PR TITLE
feat: create alias for a snap

### DIFF
--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -273,10 +273,7 @@ class Snap(object):
           SnapError if there is a problem encountered
         """
         optargs = optargs or []
-        if command == "alias":
-            _cmd = ["snap", command, *optargs]
-        else:
-            _cmd = ["snap", command, self._name, *optargs]
+        _cmd = ["snap", command, self._name, *optargs]
         try:
             return subprocess.check_output(_cmd, universal_newlines=True)
         except CalledProcessError as e:
@@ -412,16 +409,24 @@ class Snap(object):
         """Remove the refresh hold of a snap."""
         self._snap("refresh", ["--unhold"])
 
-    def alias(self, application: str, alias: str = None) -> None:
+    def alias(self, application: str, alias: Optional[str] = None) -> None:
         """Create an alias for a given application.
 
         Args:
             application: application to get an alias.
             alias: (optional) name of the alias
         """
-        if not alias:
+        if alias is None:
             alias = application
-        self._snap("alias", [f"{self.name}.{application}", alias])
+        _cmd = ["snap", "alias", f"{self.name}.{application}", alias]
+        try:
+            subprocess.check_output(_cmd, universal_newlines=True)
+        except CalledProcessError as e:
+            raise SnapError(
+                "Snap: {!r}; command {!r} failed with output = {!r}".format(
+                    self._name, _cmd, e.output
+                )
+            )
 
     def restart(
         self, services: Optional[List[str]] = None, reload: Optional[bool] = False

--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -83,7 +83,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 0
+LIBPATCH = 1
 
 
 # Regex to locate 7-bit C1 ANSI sequences
@@ -273,7 +273,10 @@ class Snap(object):
           SnapError if there is a problem encountered
         """
         optargs = optargs or []
-        _cmd = ["snap", command, self._name, *optargs]
+        if command == "alias":
+            _cmd = ["snap", command, *optargs]
+        else:
+            _cmd = ["snap", command, self._name, *optargs]
         try:
             return subprocess.check_output(_cmd, universal_newlines=True)
         except CalledProcessError as e:
@@ -408,6 +411,17 @@ class Snap(object):
     def unhold(self) -> None:
         """Remove the refresh hold of a snap."""
         self._snap("refresh", ["--unhold"])
+
+    def alias(self, application: str, alias: str = None) -> None:
+        """Create an alias for a given application.
+
+        Args:
+            application: application to get an alias.
+            alias: (optional) name of the alias
+        """
+        if not alias:
+            alias = application
+        self._snap("alias", [f"{self.name}.{application}", alias])
 
     def restart(
         self, services: Optional[List[str]] = None, reload: Optional[bool] = False

--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -273,13 +273,13 @@ class Snap(object):
           SnapError if there is a problem encountered
         """
         optargs = optargs or []
-        _cmd = ["snap", command, self._name, *optargs]
+        args = ["snap", command, self._name, *optargs]
         try:
-            return subprocess.check_output(_cmd, universal_newlines=True)
+            return subprocess.check_output(args, universal_newlines=True)
         except CalledProcessError as e:
             raise SnapError(
                 "Snap: {!r}; command {!r} failed with output = {!r}".format(
-                    self._name, _cmd, e.output
+                    self._name, args, e.output
                 )
             )
 
@@ -303,12 +303,12 @@ class Snap(object):
         else:
             services = [self._name]
 
-        _cmd = ["snap", *command, *services]
+        args = ["snap", *command, *services]
 
         try:
-            return subprocess.run(_cmd, universal_newlines=True, check=True, capture_output=True)
+            return subprocess.run(args, universal_newlines=True, check=True, capture_output=True)
         except CalledProcessError as e:
-            raise SnapError("Could not {} for snap [{}]: {}".format(_cmd, self._name, e.stderr))
+            raise SnapError("Could not {} for snap [{}]: {}".format(args, self._name, e.stderr))
 
     def get(self, key) -> str:
         """Fetch a snap configuration value.
@@ -387,11 +387,11 @@ class Snap(object):
         elif slot:
             command = command + [slot]
 
-        _cmd = ["snap", *command]
+        args = ["snap", *command]
         try:
-            subprocess.run(_cmd, universal_newlines=True, check=True, capture_output=True)
+            subprocess.run(args, universal_newlines=True, check=True, capture_output=True)
         except CalledProcessError as e:
-            raise SnapError("Could not {} for snap [{}]: {}".format(_cmd, self._name, e.stderr))
+            raise SnapError("Could not {} for snap [{}]: {}".format(args, self._name, e.stderr))
 
     def hold(self, duration: Optional[timedelta] = None) -> None:
         """Add a refresh hold to a snap.
@@ -414,17 +414,17 @@ class Snap(object):
 
         Args:
             application: application to get an alias.
-            alias: (optional) name of the alias
+            alias: (optional) name of the alias; if not provided, the application name is used.
         """
         if alias is None:
             alias = application
-        _cmd = ["snap", "alias", f"{self.name}.{application}", alias]
+        args = ["snap", "alias", f"{self.name}.{application}", alias]
         try:
-            subprocess.check_output(_cmd, universal_newlines=True)
+            subprocess.check_output(args, universal_newlines=True)
         except CalledProcessError as e:
             raise SnapError(
                 "Snap: {!r}; command {!r} failed with output = {!r}".format(
-                    self._name, _cmd, e.output
+                    self._name, args, e.output
                 )
             )
 
@@ -1011,17 +1011,17 @@ def install_local(
     Raises:
         SnapError if there is a problem encountered
     """
-    _cmd = [
+    args = [
         "snap",
         "install",
         filename,
     ]
     if classic:
-        _cmd.append("--classic")
+        args.append("--classic")
     if dangerous:
-        _cmd.append("--dangerous")
+        args.append("--dangerous")
     try:
-        result = subprocess.check_output(_cmd, universal_newlines=True).splitlines()[-1]
+        result = subprocess.check_output(args, universal_newlines=True).splitlines()[-1]
         snap_name, _ = result.split(" ", 1)
         snap_name = ansi_filter.sub("", snap_name)
 
@@ -1045,9 +1045,9 @@ def _system_set(config_item: str, value: str) -> None:
         config_item: name of snap system setting. E.g. 'refresh.hold'
         value: value to assign
     """
-    _cmd = ["snap", "set", "system", "{}={}".format(config_item, value)]
+    args = ["snap", "set", "system", "{}={}".format(config_item, value)]
     try:
-        subprocess.check_call(_cmd, universal_newlines=True)
+        subprocess.check_call(args, universal_newlines=True)
     except CalledProcessError:
         raise SnapError("Failed setting system config '{}' to '{}'".format(config_item, value))
 

--- a/tests/integration/test_dnf.py
+++ b/tests/integration/test_dnf.py
@@ -26,9 +26,9 @@ def test_query_dnf_and_package() -> None:
     assert package.name == "slurm-slurmd"
     assert package.arch == "x86_64"
     assert package.epoch is None
-    assert package.version == "22.05.6"
-    assert package.release == "3.el9"
-    assert package.full_version == "22.05.6-3.el9"
+    assert package.version == "22.05.9"
+    assert package.release == "1.el9"
+    assert package.full_version == "22.05.9-1.el9"
     assert package.repo == "epel"
 
 

--- a/tests/integration/test_snap.py
+++ b/tests/integration/test_snap.py
@@ -243,10 +243,6 @@ def test_alias():
     cache = snap.SnapCache()
     lxd = cache["lxd"]
     lxd.alias("lxc", "testlxc")
-    result = check_output(["snap", "aliases"])
-    found_alias = False
-    for line in result.decode().split("\n")[1:]:
-        if ["lxd.lxc", "testlxc", "manual"] == [val for val in line.split(" ") if val]:
-            found_alias = True
-            break
-    assert found_alias
+    result = check_output(["snap", "aliases"], text=True)
+    found = any(line.split() == ["lxd.lxc", "testlxc", "manual"] for line in result.splitlines())
+    assert found, result

--- a/tests/integration/test_snap.py
+++ b/tests/integration/test_snap.py
@@ -237,3 +237,16 @@ def test_reset_hold_refresh():
     snap.hold_refresh(0)
     result = check_output(["snap", "refresh", "--time"])
     assert "hold: " not in result.decode()
+
+
+def test_alias():
+    cache = snap.SnapCache()
+    lxd = cache["lxd"]
+    lxd.alias("lxc", "testlxc")
+    result = check_output(["snap", "aliases"])
+    found_alias = False
+    for line in result.decode().split("\n")[1:]:
+        if ["lxd.lxc", "testlxc", "manual"] == [val for val in line.split(" ") if val]:
+            found_alias = True
+            break
+    assert found_alias

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -686,13 +686,8 @@ class TestSnapBareMethods(unittest.TestCase):
             returncode=1, cmd=["snap", "alias", "foo.bar", "baz"]
         )
         foo = snap.Snap("foo", snap.SnapState.Latest, "stable", "1", "classic")
-        with self.assertRaises(snap.SnapError) as ctx:
+        with self.assertRaises(snap.SnapError):
             foo.alias("bar", "baz")
-        self.assertEqual("<charms.operator_libs_linux.v2.snap.SnapError>", ctx.exception.name)
-        self.assertEqual(
-            "Snap: 'foo'; command ['snap', 'alias', 'foo.bar', 'baz'] failed with output = None",
-            ctx.exception.message,
-        )
         mock_subprocess.assert_called_once_with(
             ["snap", "alias", "foo.bar", "baz"],
             universal_newlines=True,

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -661,3 +661,21 @@ class TestSnapBareMethods(unittest.TestCase):
                 universal_newlines=True,
             )
             mock_subprocess.reset_mock()
+
+    @patch("charms.operator_libs_linux.v2.snap.subprocess.check_output")
+    def test_alias(self, mock_subprocess):
+        mock_subprocess.return_value = 0
+        foo = snap.Snap("foo", snap.SnapState.Latest, "stable", "1", "classic")
+        foo.alias("bar", "baz")
+        mock_subprocess.assert_called_once_with(
+            ["snap", "alias", "foo.bar", "baz"],
+            universal_newlines=True,
+        )
+        mock_subprocess.reset_mock()
+
+        foo.alias("bar")
+        mock_subprocess.assert_called_once_with(
+            ["snap", "alias", "foo.bar", "bar"],
+            universal_newlines=True,
+        )
+        mock_subprocess.reset_mock()


### PR DESCRIPTION
## Issue
We would like to be able to create snap aliases using the charm library

## Solution
Add `alias` method to create aliases.