### PR TITLE
Enable systemd service methods to accept multiple args

### DIFF
--- a/lib/charms/operator_libs_linux/v1/systemd.py
+++ b/lib/charms/operator_libs_linux/v1/systemd.py
@@ -53,7 +53,6 @@ __all__ = [  # Don't export `_systemctl`. (It's not the intended way of using th
 
 import logging
 import subprocess
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 

--- a/lib/charms/operator_libs_linux/v1/systemd.py
+++ b/lib/charms/operator_libs_linux/v1/systemd.py
@@ -64,7 +64,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 
 class SystemdError(Exception):

--- a/lib/charms/operator_libs_linux/v1/systemd.py
+++ b/lib/charms/operator_libs_linux/v1/systemd.py
@@ -37,6 +37,7 @@ success = service_reload("nginx", restart_on_failure=True)
 """
 
 __all__ = [  # Don't export `_systemctl`. (It's not the intended way of using this lib.)
+    "SystemdError",
     "daemon_reload",
     "service_disable",
     "service_enable",

--- a/lib/charms/operator_libs_linux/v1/systemd.py
+++ b/lib/charms/operator_libs_linux/v1/systemd.py
@@ -136,7 +136,7 @@ def service_start(*args: str) -> bool:
     """Start a system service.
 
     Args:
-        *args: Arguments to pass to `systemctl start`.
+        *args: Arguments to pass to `systemctl start` (normally the service name).
 
     Returns:
         On success, this function returns True for historical reasons.
@@ -151,7 +151,7 @@ def service_stop(*args: str) -> bool:
     """Stop a system service.
 
     Args:
-        *args: Arguments to pass to `systemctl stop`.
+        *args: Arguments to pass to `systemctl stop` (normally the service name).
 
     Returns:
         On success, this function returns True for historical reasons.
@@ -166,7 +166,7 @@ def service_restart(*args: str) -> bool:
     """Restart a system service.
 
     Args:
-        *args: Arguments to pass to `systemctl restart`.
+        *args: Arguments to pass to `systemctl restart` (normally the service name).
 
     Returns:
         On success, this function returns True for historical reasons.
@@ -181,7 +181,7 @@ def service_enable(*args: str) -> bool:
     """Enable a system service.
 
     Args:
-        *args: Arguments to pass to `systemctl enable`.
+        *args: Arguments to pass to `systemctl enable` (normally the service name).
 
     Returns:
         On success, this function returns True for historical reasons.
@@ -196,7 +196,7 @@ def service_disable(*args: str) -> bool:
     """Disable a system service.
 
     Args:
-        *args: Arguments to pass to `systemctl disable`.
+        *args: Arguments to pass to `systemctl disable` (normally the service name).
 
     Returns:
         On success, this function returns True for historical reasons.

--- a/tests/integration/test_systemd.py
+++ b/tests/integration/test_systemd.py
@@ -59,22 +59,23 @@ def test_service():
 
 def test_pause_and_resume():
     # Verify that we can disable and re-enable a service.
-    assert service_pause("cron")
+    service_pause("cron")
     assert not service_running("cron")
-    assert service_resume("cron")
+    service_resume("cron")
     assert service_running("cron")
 
 
 def test_restart():
     # Verify that we seem to be able to restart a service.
-    assert service_restart("cron")
+    service_restart("cron")
+    assert service_running("cron")
 
 
 def test_stop_and_start():
     # Verify that we can stop and start a service.
-    assert service_stop("cron")
+    service_stop("cron")
     assert not service_running("cron")
-    assert service_start("cron")
+    service_start("cron")
     assert service_running("cron")
 
 
@@ -86,10 +87,11 @@ def test_reload():
         pass
     else:
         raise AssertionError("cron does not support reload, but we didn't raise and error.")
-    assert service_reload("apparmor")
+
+    service_reload("apparmor")
 
     # The following is observed behavior. Not sure how happy I am about it.
-    assert service_reload("cron", restart_on_failure=True)
+    service_reload("cron", restart_on_failure=True)
 
 
 def test_daemon_reload():
@@ -107,5 +109,5 @@ def test_daemon_reload():
         f.write(content)
 
     assert needs_reload("cron")
-    assert daemon_reload()
+    daemon_reload()
     assert not needs_reload("cron")

--- a/tests/integration/test_systemd.py
+++ b/tests/integration/test_systemd.py
@@ -59,23 +59,22 @@ def test_service():
 
 def test_pause_and_resume():
     # Verify that we can disable and re-enable a service.
-    service_pause("cron")
+    assert service_pause("cron")
     assert not service_running("cron")
-    service_resume("cron")
+    assert service_resume("cron")
     assert service_running("cron")
 
 
 def test_restart():
     # Verify that we seem to be able to restart a service.
-    service_restart("cron")
-    assert service_running("cron")
+    assert service_restart("cron")
 
 
 def test_stop_and_start():
     # Verify that we can stop and start a service.
-    service_stop("cron")
+    assert service_stop("cron")
     assert not service_running("cron")
-    service_start("cron")
+    assert service_start("cron")
     assert service_running("cron")
 
 
@@ -87,11 +86,10 @@ def test_reload():
         pass
     else:
         raise AssertionError("cron does not support reload, but we didn't raise and error.")
-
-    service_reload("apparmor")
+    assert service_reload("apparmor")
 
     # The following is observed behavior. Not sure how happy I am about it.
-    service_reload("cron", restart_on_failure=True)
+    assert service_reload("cron", restart_on_failure=True)
 
 
 def test_daemon_reload():
@@ -109,5 +107,5 @@ def test_daemon_reload():
         f.write(content)
 
     assert needs_reload("cron")
-    daemon_reload()
+    assert daemon_reload()
     assert not needs_reload("cron")

--- a/tests/unit/test_systemd.py
+++ b/tests/unit/test_systemd.py
@@ -30,8 +30,8 @@ def with_mock_subp(func):
                 else:
                     mock_proc = MagicMock()
                     mock_proc.returncode = code
-                    mock_proc.stdout = subprocess.PIPE,
-                    mock_proc.stderr = subprocess.STDOUT,
+                    mock_proc.stdout = (subprocess.PIPE,)
+                    mock_proc.stderr = (subprocess.STDOUT,)
                     mock_proc.check = check
                     side_effects.append(mock_proc)
 
@@ -62,7 +62,9 @@ class TestSystemD(unittest.TestCase):
 
         mockp, kw = make_mock([1], check=True)
 
-        self.assertRaises(systemd.SystemdError, systemd._systemctl, "is-active", "mysql", check=True)
+        self.assertRaises(
+            systemd.SystemdError, systemd._systemctl, "is-active", "mysql", check=True
+        )
         mockp.assert_called_with(["systemctl", "is-active", "mysql"], **kw)
 
     @with_mock_subp
@@ -86,7 +88,15 @@ class TestSystemD(unittest.TestCase):
         self.assertTrue(is_failed)
 
         is_failed = systemd.service_failed("mysql")
-        mockp.assert_called_with(["systemctl", "--quiet", "is-failed", "mysql", ], **kw)
+        mockp.assert_called_with(
+            [
+                "systemctl",
+                "--quiet",
+                "is-failed",
+                "mysql",
+            ],
+            **kw,
+        )
         self.assertFalse(is_failed)
 
     @with_mock_subp


### PR DESCRIPTION
Hello - this pull request extends the service methods in the systemd charm library to now accept multiple arguments. I made this change so that when charm authors need to pass extra parameters to `systemctl`, they do not need to directly call the private `_systemctl` method and can instead pass the extra arguments to via the public `service_*` methods.

For example, say you have a service that takes several seconds to start. Using `service_start(...)` in its currently implementation will cause Python to block until systemctl returns an exit code (`Popen.wait()`). This is inconvenient especially if you have a service that could take 30+ seconds to start. With the implementation this pull request proposes, you can pass the `--no-block` option to `service_start(...)` and let the charm continue on its way while the systemd starts the service in the background.

### Notes

* I haven't touched the _LIBAPI_ or _LIBPATCH_ versions. I will update them after reviews/approval.
* Public method signatures are the same so we shouldn't need to update the _LIBAPI_ version of the systemd charmlib. I did have to update the unit tests however because I changed the back-end implementation of `_systemctl(...)`. It is now similar to how `_dnf(...)` is implemented in the dnf charmlib.