### PR TITLE
Allow `Snap.get` and `Snap.set` to respect the Python's built-in types

### DIFF
--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -310,11 +310,11 @@ class Snap(object):
         except CalledProcessError as e:
             raise SnapError("Could not {} for snap [{}]: {}".format(args, self._name, e.stderr))
 
-    def get(self, key: str = "", *, typed: bool = False) -> Any:
+    def get(self, key: Optional[str], *, typed: bool = False) -> Any:
         """Fetch snap configuration values.
 
         Args:
-            key: the key to retrieve. Default to retrieve all values.
+            key: the key to retrieve. Default to retrieve all values for typed=True.
             typed: set to True to retrieve typed values (set with typed=True).
                 Default is to return a string.
         """
@@ -323,6 +323,9 @@ class Snap(object):
             if key:
                 return config.get(key)
             return config
+
+        if not key:
+            raise TypeError("Key must be provided when typed=False")
 
         return self._snap("get", [key]).strip()
 

--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -332,7 +332,7 @@ class Snap(object):
         """
         args = []
         for key, val in configs.items():
-            value = json.dumps(val) if use_json else "'{}'".format(val)
+            value = json.dumps(val) if use_json else '"{}"'.format(val)
             args.append("{}={}".format(key, value))
 
         return self._snap("set", args)

--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -83,7 +83,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 
 # Regex to locate 7-bit C1 ANSI sequences

--- a/tests/integration/test_snap.py
+++ b/tests/integration/test_snap.py
@@ -52,7 +52,7 @@ def test_snap_refresh():
     lxd.ensure(snap.SnapState.Latest, classic=False, channel="latest/candidate", cohort="+")
 
 
-def test_snap_set_and_get_with_json():
+def test_snap_set_and_get_with_typed():
     cache = snap.SnapCache()
     lxd = cache["lxd"]
     lxd.ensure(snap.SnapState.Latest, channel="latest")
@@ -75,20 +75,20 @@ def test_snap_set_and_get_with_json():
         "ceph.external": "false",
     }
 
-    lxd.set(configs, use_json=True)
+    lxd.set(configs, typed=True)
 
-    assert lxd.get("true", use_json=True)
-    assert not lxd.get("false", use_json=True)
+    assert lxd.get("true", typed=True)
+    assert not lxd.get("false", typed=True)
     with pytest.raises(snap.SnapError):
-        lxd.get("null", use_json=True)
-    assert lxd.get("integer", use_json=True) == 1
-    assert lxd.get("float", use_json=True) == 2.0
-    assert lxd.get("list", use_json=True) == [1, 2.0, True, False, None]
+        lxd.get("null", typed=True)
+    assert lxd.get("integer", typed=True) == 1
+    assert lxd.get("float", typed=True) == 2.0
+    assert lxd.get("list", typed=True) == [1, 2.0, True, False, None]
 
     # Note that `"null": None` will be missing here because `key=null` will not
     # be set (because it means unset in snap). However, `key=[null]` will be
     # okay, and that's why `None` exists in "list".
-    assert lxd.get("dict", use_json=True) == {
+    assert lxd.get("dict", typed=True) == {
         "true": True,
         "false": False,
         "integer": 1,
@@ -96,26 +96,26 @@ def test_snap_set_and_get_with_json():
         "list": [1, 2.0, True, False, None],
     }
 
-    assert lxd.get("dict.true", use_json=True)
-    assert not lxd.get("dict.false", use_json=True)
+    assert lxd.get("dict.true", typed=True)
+    assert not lxd.get("dict.false", typed=True)
     with pytest.raises(snap.SnapError):
-        lxd.get("dict.null", use_json=True)
-    assert lxd.get("dict.integer", use_json=True) == 1
-    assert lxd.get("dict.float", use_json=True) == 2.0
-    assert lxd.get("dict.list", use_json=True) == [1, 2.0, True, False, None]
+        lxd.get("dict.null", typed=True)
+    assert lxd.get("dict.integer", typed=True) == 1
+    assert lxd.get("dict.float", typed=True) == 2.0
+    assert lxd.get("dict.list", typed=True) == [1, 2.0, True, False, None]
 
-    assert lxd.get("criu.enable", use_json=True) == "true"
-    assert lxd.get("ceph.external", use_json=True) == "false"
+    assert lxd.get("criu.enable", typed=True) == "true"
+    assert lxd.get("ceph.external", typed=True) == "false"
 
 
-def test_snap_set_and_get_without_json():
+def test_snap_set_and_get_untyped():
     cache = snap.SnapCache()
     lxd = cache["lxd"]
     lxd.ensure(snap.SnapState.Latest, channel="latest")
 
-    lxd.set({"foo": "true", "bar": True}, use_json=False)
-    assert lxd.get("foo", use_json=False) == "true"
-    assert lxd.get("bar", use_json=False) == "True"
+    lxd.set({"foo": "true", "bar": True}, typed=False)
+    assert lxd.get("foo", typed=False) == "true"
+    assert lxd.get("bar", typed=False) == "True"
 
 
 def test_unset_key_raises_snap_error():

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -548,37 +548,26 @@ class TestSnapBareMethods(unittest.TestCase):
         self.assertIn("Failed to install or refresh snap(s): nothere", ctx.exception.message)
 
     @patch("charms.operator_libs_linux.v2.snap.subprocess.check_output")
-    def test_snap_set(self, mock_subprocess):
+    def test_snap_set_typed(self, mock_subprocess):
         foo = snap.Snap("foo", snap.SnapState.Present, "stable", "1", "classic")
 
-        configs = {
-            "true": True,
-            "false": False,
-            "null": None,
-            "integer": 1,
-            "float": 2.0,
-            "list": [1, 2.0, True, False],
-            "dict": {
-                "true": True,
-                "false": False,
-                "null": None,
-                "integer": 1,
-                "float": 2.0,
-                "list": [1, 2.0, True, False],
-            },
-        }
+        config = {"n": 42, "s": "string", "d": {"nested": True}}
 
-        foo.set(configs, use_json=True)
-        args = ["{}={}".format(key, json.dumps(val)) for key, val in configs.items()]
+        foo.set(config, typed=True)
         mock_subprocess.assert_called_with(
-            ["snap", "set", "foo", *args],
+            ["snap", "set", "foo", "-t", "n=42", 's="string"', 'd={"nested": true}'],
             universal_newlines=True,
         )
 
-        foo.set(configs, use_json=False)
-        args = ['{}="{}"'.format(key, val) for key, val in configs.items()]
+    @patch("charms.operator_libs_linux.v2.snap.subprocess.check_output")
+    def test_snap_set_untyped(self, mock_subprocess):
+        foo = snap.Snap("foo", snap.SnapState.Present, "stable", "1", "classic")
+
+        config = {"n": 42, "s": "string", "d": {"nested": True}}
+
+        foo.set(config, typed=False)
         mock_subprocess.assert_called_with(
-            ["snap", "set", "foo", *args],
+            ["snap", "set", "foo", "n=42", "s=string", "d={'nested': True}"],
             universal_newlines=True,
         )
 


### PR DESCRIPTION
This patches added a `use_json` optional arguments to `Snap.get` and `Snap.set` so that the two methods can make use of the built-in types in Python while setting / getting snap configurations. 

The new option allows snap config options to be compared more natively, for example:

```python
s = snap.SnapCache()["some-snap"]
s.set({"foo": True}, use_json=True)

assert s.get("foo", use_json=True) # instead of == "True"
```

Although the required argument for the two methods did not change, the behaviour still differs a bit when setting `use_json=True`. Therefore,  the default `use_json` is set to `False` for backward compatibility. 

Fixes: #107 