### PR TITLE
Increase default SnapClient timeout to 30 seconds

### DIFF
--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -83,7 +83,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 
 # Regex to locate 7-bit C1 ANSI sequences

--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -692,7 +692,7 @@ class SnapClient:
         socket_path: str = "/run/snapd.socket",
         opener: Optional[urllib.request.OpenerDirector] = None,
         base_url: str = "http://localhost/v2/",
-        timeout: float = 5.0,
+        timeout: float = 30.0,
     ):
         """Initialize a client instance.
 
@@ -701,7 +701,7 @@ class SnapClient:
             opener: specifies an opener for unix socket, if unspecified a default is used
             base_url: base url for making requests to the snap client. Defaults to
                 http://localhost/v2/
-            timeout: timeout in seconds to use when making requests to the API. Default is 5.0s.
+            timeout: timeout in seconds to use when making requests to the API. Default is 30.0s.
         """
         if opener is None:
             opener = self._get_default_opener(socket_path)


### PR DESCRIPTION
### Summary

Increase default SnapClient timeout to 30 seconds

### Description

SnapClient has a default timeout of 5 seconds for all RPCs to
the snapd socket. If any operation takes more, an exception is
raised to the caller.

We have seen this causing issues in slow CI environments, where
a simple config-changed hook will attempt to check if a snap is
installed, timeout and move the unit to a blocked status (causing
the CI run to fail). This is augmented by the fact that typically
SnapCache is used instead of SnapClient, which only uses the default
value and does not provide a way to configure the timeout.

Simply increasing the timeout is enough to tackle the flakes.

### Notes

A possible alternative could be to surface the timeout option to SnapCache,
but that then would require each consumer of the library to set the timeout.