### PR TITLE
docs: add workflow badges to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Linux Libraries for Operator Framework Charms
 
+![Release Libraries](https://github.com/canonical/operator-libs-linux/actions/workflows/release-libs.yaml/badge.svg)
+![Release to Charmhub](https://github.com/canonical/operator-libs-linux/actions/workflows/release.yaml/badge.svg)
+
 ## Description
 
 The `operator-libs-linux` charm provides a set of [charm libraries] which can be used for managing and manipulating Debian packages, [snap packages], system repositories, users and groups, and other operations


### PR DESCRIPTION
Add badges for the Github workflows (except PR checks) to the README.

These will show when viewing the README in a markdown reader that loads external images (e.g. on GitHub itself) but more importantly also show the CI status on [the Juju releases page](https://releases.juju.is/).