### PR TITLE
apt.py: use CalledProcessError.stderr in exceptions instead of output/stdout

### DIFF
--- a/lib/charms/operator_libs_linux/v0/apt.py
+++ b/lib/charms/operator_libs_linux/v0/apt.py
@@ -253,7 +253,7 @@ class DebianPackage:
             subprocess.run(_cmd, capture_output=True, check=True, env=env)
         except CalledProcessError as e:
             raise PackageError(
-                "Could not {} package(s) [{}]: {}".format(command, [*package_names], e.output)
+                "Could not {} package(s) [{}]: {}".format(command, [*package_names], e.stderr)
             ) from None
 
     def _add(self) -> None:
@@ -476,7 +476,7 @@ class DebianPackage:
             )
         except CalledProcessError as e:
             raise PackageError(
-                "Could not list packages in apt-cache: {}".format(e.output)
+                "Could not list packages in apt-cache: {}".format(e.stderr)
             ) from None
 
         pkg_groups = output.strip().split("\n\n")

--- a/lib/charms/operator_libs_linux/v0/apt.py
+++ b/lib/charms/operator_libs_linux/v0/apt.py
@@ -250,7 +250,7 @@ class DebianPackage:
         try:
             env = os.environ.copy()
             env["DEBIAN_FRONTEND"] = "noninteractive"
-            subprocess.run(_cmd, capture_output=True, check=True, env=env)
+            subprocess.run(_cmd, capture_output=True, check=True, text=True, env=env)
         except CalledProcessError as e:
             raise PackageError(
                 "Could not {} package(s) [{}]: {}".format(command, [*package_names], e.stderr)

--- a/lib/charms/operator_libs_linux/v0/apt.py
+++ b/lib/charms/operator_libs_linux/v0/apt.py
@@ -122,7 +122,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 12
+LIBPATCH = 13
 
 
 VALID_SOURCE_TYPES = ("deb", "deb-src")

--- a/tests/integration/test_apt.py
+++ b/tests/integration/test_apt.py
@@ -27,6 +27,20 @@ def test_install_package():
     assert get_command_path("jq") == "/usr/bin/jq"
 
 
+def test_install_package_error():
+    try:
+        package = apt.DebianPackage(
+            "ceci-n'est-pas-un-paquet",
+            "1.0",
+            "",
+            "amd64",
+            apt.PackageState.Available,
+        )
+        package.ensure(apt.PackageState.Present)
+    except apt.PackageError as e:
+        assert "Unable to locate package" in str(e)
+
+
 def test_remove_package():
     # First ensure the package is present
     cfssl = apt.DebianPackage.from_apt_cache("golang-cfssl")
@@ -77,3 +91,10 @@ def test_list_file_generation_external_repository():
     apt.add_package("mongodb-org")
 
     assert get_command_path("mongod") == "/usr/bin/mongod"
+
+
+def test_from_apt_cache_error():
+    try:
+        apt.DebianPackage.from_apt_cache("ceci-n'est-pas-un-paquet")
+    except apt.PackageError as e:
+        assert "No packages found" in str(e)

--- a/tests/unit/test_apt.py
+++ b/tests/unit/test_apt.py
@@ -324,6 +324,7 @@ class TestApt(unittest.TestCase):
             ],
             capture_output=True,
             check=True,
+            text=True,
             env={"DEBIAN_FRONTEND": "noninteractive", "PING": "PONG"},
         )
         self.assertEqual(pkg.state, apt.PackageState.Latest)
@@ -333,6 +334,7 @@ class TestApt(unittest.TestCase):
             ["apt-get", "-y", "remove", "mocktester=1:1.2.3-4"],
             capture_output=True,
             check=True,
+            text=True,
             env={"DEBIAN_FRONTEND": "noninteractive", "PING": "PONG"},
         )
 
@@ -409,6 +411,7 @@ class TestAptBareMethods(unittest.TestCase):
             ],
             capture_output=True,
             check=True,
+            text=True,
             env={"DEBIAN_FRONTEND": "noninteractive"},
         )
         self.assertEqual(foo.present, True)
@@ -420,6 +423,7 @@ class TestAptBareMethods(unittest.TestCase):
             ["apt-get", "-y", "remove", "zsh=5.8-3ubuntu1"],
             capture_output=True,
             check=True,
+            text=True,
             env={"DEBIAN_FRONTEND": "noninteractive"},
         )
         self.assertEqual(bar.present, False)
@@ -454,6 +458,7 @@ class TestAptBareMethods(unittest.TestCase):
             ],
             capture_output=True,
             check=True,
+            text=True,
             env={"DEBIAN_FRONTEND": "noninteractive"},
         )
         mock_subprocess.assert_any_call(
@@ -466,6 +471,7 @@ class TestAptBareMethods(unittest.TestCase):
             ],
             capture_output=True,
             check=True,
+            text=True,
             env={"DEBIAN_FRONTEND": "noninteractive"},
         )
         self.assertEqual(foo[0].present, True)
@@ -477,12 +483,14 @@ class TestAptBareMethods(unittest.TestCase):
             ["apt-get", "-y", "remove", "vim=2:8.1.2269-1ubuntu5"],
             capture_output=True,
             check=True,
+            text=True,
             env={"DEBIAN_FRONTEND": "noninteractive"},
         )
         mock_subprocess.assert_any_call(
             ["apt-get", "-y", "remove", "zsh=5.8-3ubuntu1"],
             capture_output=True,
             check=True,
+            text=True,
             env={"DEBIAN_FRONTEND": "noninteractive"},
         )
         self.assertEqual(bar[0].present, False)


### PR DESCRIPTION
as mentioned in #114 , this patch changes some select `PackageError` exceptions to consume `CalledProcessError.stderr` instead of `CalledProcessError.output` (an alias for `stdout`).

These exceptions should now actually contain the error output of the subprocesses with non-zero exit codes.