### PR TITLE
Add logging to snap install steps

### DIFF
--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -277,7 +277,6 @@ class Snap(object):
         try:
             return subprocess.check_output(args, universal_newlines=True)
         except CalledProcessError as e:
-            logger.error("Error when running %s command: %s", " ".join(args), e)
             raise SnapError(
                 "Snap: {!r}; command {!r} failed with output = {!r}".format(
                     self._name, args, e.output

--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -277,6 +277,7 @@ class Snap(object):
         try:
             return subprocess.check_output(args, universal_newlines=True)
         except CalledProcessError as e:
+            logger.error("Error when running %s command: %s", " ".join(args), e)
             raise SnapError(
                 "Snap: {!r}; command {!r} failed with output = {!r}".format(
                     self._name, args, e.output
@@ -581,12 +582,14 @@ class Snap(object):
             if self._state not in (SnapState.Present, SnapState.Latest):
                 # The snap is not installed, so we install it.
                 logger.info(
-                    f"Installing snap {self._name} revision {revision}, tracking {channel}"
+                    "Installing snap %s, revision %s, tracking %s", self._name, revision, channel
                 )
                 self._install(channel, cohort, revision)
             else:
                 # The snap is installed, but we are changing it (e.g., switching channels).
-                logger.info(f"Refreshing snap {self._name} to revision {revision} in {channel}")
+                logger.info(
+                    "Refreshing snap %s, revision %s, tracking %s", self._name, revision, channel
+                )
                 self._refresh(channel=channel, cohort=cohort, revision=revision, devmode=devmode)
             logger.info("The snap installation completed successfully")
 

--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -83,7 +83,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 
 # Regex to locate 7-bit C1 ANSI sequences
@@ -580,10 +580,13 @@ class Snap(object):
             # We are installing or refreshing a snap.
             if self._state not in (SnapState.Present, SnapState.Latest):
                 # The snap is not installed, so we install it.
+                logger.info(f"Installing snap {self._name} revision {revision}, tracking {channel}")
                 self._install(channel, cohort, revision)
             else:
                 # The snap is installed, but we are changing it (e.g., switching channels).
+                logger.info(f"Refreshing snap {self._name} to revision {revision} in {channel}")
                 self._refresh(channel=channel, cohort=cohort, revision=revision, devmode=devmode)
+            logger.info("The snap installation completed successfully")
 
         self._update_snap_apps()
         self._state = state

--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -277,7 +277,6 @@ class Snap(object):
         try:
             return subprocess.check_output(args, universal_newlines=True)
         except CalledProcessError as e:
-            logger.warning(e)
             raise SnapError(
                 "Snap: {!r}; command {!r} failed with output = {!r}".format(
                     self._name, args, e.output

--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -277,6 +277,7 @@ class Snap(object):
         try:
             return subprocess.check_output(args, universal_newlines=True)
         except CalledProcessError as e:
+            logger.warning(e)
             raise SnapError(
                 "Snap: {!r}; command {!r} failed with output = {!r}".format(
                     self._name, args, e.output

--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -580,7 +580,9 @@ class Snap(object):
             # We are installing or refreshing a snap.
             if self._state not in (SnapState.Present, SnapState.Latest):
                 # The snap is not installed, so we install it.
-                logger.info(f"Installing snap {self._name} revision {revision}, tracking {channel}")
+                logger.info(
+                    f"Installing snap {self._name} revision {revision}, tracking {channel}"
+                )
                 self._install(channel, cohort, revision)
             else:
                 # The snap is installed, but we are changing it (e.g., switching channels).

--- a/tests/integration/test_snap.py
+++ b/tests/integration/test_snap.py
@@ -176,7 +176,7 @@ def test_snap_ensure_revision():
 
     edge_revision = None
     for line in snap_info_juju:
-        match = re.search(r"latest/edge.*\((\d+)\)", line)
+        match = re.search(r"3/stable.*\((\d+)\)", line)
 
         if match:
             edge_revision = match.group(1)

--- a/tests/integration/test_snap.py
+++ b/tests/integration/test_snap.py
@@ -176,6 +176,7 @@ def test_snap_ensure_revision():
 
     edge_revision = None
     for line in snap_info_juju:
+        logger.info(line)
         match = re.search(r"latest/edge.*\((\d+)\)", line)
 
         if match:

--- a/tests/integration/test_snap.py
+++ b/tests/integration/test_snap.py
@@ -176,7 +176,6 @@ def test_snap_ensure_revision():
 
     edge_revision = None
     for line in snap_info_juju:
-        logger.info(line)
         match = re.search(r"latest/edge.*\((\d+)\)", line)
 
         if match:


### PR DESCRIPTION
Add log messages to signal snap installation/refresh steps, so the user can check how long it took.

Motivated by https://warthogs.atlassian.net/browse/DPE-3845