### PR TITLE
Prevent refresh by revision when the snap is already on that revision

### DIFF
--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -83,7 +83,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 
 # Regex to locate 7-bit C1 ANSI sequences

--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -584,13 +584,16 @@ class Snap(object):
                     "Installing snap %s, revision %s, tracking %s", self._name, revision, channel
                 )
                 self._install(channel, cohort, revision)
-            else:
+                logger.info("The snap installation completed successfully")
+            elif (revision is None) or (revision != self._revision):
                 # The snap is installed, but we are changing it (e.g., switching channels).
                 logger.info(
                     "Refreshing snap %s, revision %s, tracking %s", self._name, revision, channel
                 )
                 self._refresh(channel=channel, cohort=cohort, revision=revision, devmode=devmode)
-            logger.info("The snap installation completed successfully")
+                logger.info("The snap refresh completed successfully")
+            else:
+                logger.info("Snap refresh was unnecessary %s", self._name)
 
         self._update_snap_apps()
         self._state = state

--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -585,7 +585,7 @@ class Snap(object):
                 )
                 self._install(channel, cohort, revision)
                 logger.info("The snap installation completed successfully")
-            elif (revision is None) or (revision != self._revision):
+            elif revision is None or revision != self._revision:
                 # The snap is installed, but we are changing it (e.g., switching channels).
                 logger.info(
                     "Refreshing snap %s, revision %s, tracking %s", self._name, revision, channel
@@ -593,7 +593,7 @@ class Snap(object):
                 self._refresh(channel=channel, cohort=cohort, revision=revision, devmode=devmode)
                 logger.info("The snap refresh completed successfully")
             else:
-                logger.info("Snap refresh was unnecessary %s", self._name)
+                logger.info("Refresh of snap %s was unnecessary", self._name)
 
         self._update_snap_apps()
         self._state = state

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -558,7 +558,7 @@ class TestSnapBareMethods(unittest.TestCase):
         )
 
         mock_check_output.reset_mock()
-        # ensure that calling refresh with the same revision doesn't subprocess out
+        # Ensure that calling refresh with the same revision doesn't subprocess out.
         snap.ensure("curl", "latest", classic=True, revision="233", cohort="+")
         mock_check_output.assert_not_called()
 

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -543,12 +543,10 @@ class TestSnapBareMethods(unittest.TestCase):
             universal_newlines=True,
         )
 
-    @patch("charms.operator_libs_linux.v2.snap.subprocess")
-    def test_revision_doesnt_refresh(self, mock_subprocess):
-        mock_subprocess.check_output = MagicMock()
-
+    @patch("charms.operator_libs_linux.v2.snap.subprocess.check_output")
+    def test_revision_doesnt_refresh(self, mock_check_output):
         snap.add("curl", revision="233", cohort="+")
-        mock_subprocess.check_output.assert_called_with(
+        mock_check_output.assert_called_with(
             [
                 "snap",
                 "install",
@@ -559,10 +557,10 @@ class TestSnapBareMethods(unittest.TestCase):
             universal_newlines=True,
         )
 
-        mock_subprocess.reset_mock()
+        mock_check_output.reset_mock()
         # ensure that calling refresh with the same revision doesn't subprocess out
         snap.ensure("curl", "latest", classic=True, revision="233", cohort="+")
-        mock_subprocess.check_output.assert_not_called()
+        mock_check_output.assert_not_called()
 
     @patch("charms.operator_libs_linux.v2.snap.subprocess.check_output")
     def test_can_ensure_states(self, mock_subprocess):

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -543,6 +543,27 @@ class TestSnapBareMethods(unittest.TestCase):
             universal_newlines=True,
         )
 
+    @patch("charms.operator_libs_linux.v2.snap.subprocess")
+    def test_revision_doesnt_refresh(self, mock_subprocess):
+        mock_subprocess.check_output = MagicMock()
+
+        snap.add("curl", revision="233", cohort="+")
+        mock_subprocess.check_output.assert_called_with(
+            [
+                "snap",
+                "install",
+                "curl",
+                '--revision="233"',
+                '--cohort="+"',
+            ],
+            universal_newlines=True,
+        )
+
+        mock_subprocess.reset_mock()
+        # ensure that calling refresh with the same revision doesn't subprocess out
+        snap.ensure("curl", "latest", classic=True, revision="233", cohort="+")
+        mock_subprocess.check_output.assert_not_called()
+
     @patch("charms.operator_libs_linux.v2.snap.subprocess.check_output")
     def test_can_ensure_states(self, mock_subprocess):
         mock_subprocess.return_value = 0


### PR DESCRIPTION
Addresses issue #120 

`snap refresh --revision=xyz` causes snapd to restart the service provided by that snap, even if the revision is already on the machine. In this limited case, we should not refresh the snap if it is already on the correct revision.