### PR TITLE
Adjustments to test with python 3.12

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.8", "3.10"]
+        python-version: ["3.8", "3.10", "3.12"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,4 @@ max-complexity = 14
 
 [tool.codespell]
 skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.vscode,.coverage"
+ignore-words-list = "assertIn"

--- a/tests/unit/test_sysctl.py
+++ b/tests/unit/test_sysctl.py
@@ -208,8 +208,9 @@ class TestSysctlConfig(unittest.TestCase):
         config._desired_config = {"vm.swappiness": "0", "other_value": "10"}
         snapshot = config._create_snapshot()
 
-        assert mock_output.called_with(["sysctl", "vm.swappiness", "-n"])
-        assert mock_output.called_with(["sysctl", "other_value", "-n"])
+        mock_output.assert_called_once_with(
+            ["sysctl", "-n", "vm.swappiness", "other_value"], stderr=-2, universal_newlines=True
+        )
         assert snapshot == {"vm.swappiness": "1", "other_value": "5"}
 
     @patch("charms.operator_libs_linux.v0.sysctl.check_output")
@@ -222,7 +223,9 @@ class TestSysctlConfig(unittest.TestCase):
         snapshot = {"vm.swappiness": "1", "other_value": "5"}
         config._restore_snapshot(snapshot)
 
-        assert mock_output.called_with(["sysctl", "vm.swappiness=1", "other_value=5"])
+        mock_output.assert_called_once_with(
+            ["sysctl", "vm.swappiness=1", "other_value=5"], stderr=-2, universal_newlines=True
+        )
 
     @patch("charms.operator_libs_linux.v0.sysctl.check_output")
     @patch("charms.operator_libs_linux.v0.sysctl.Config._load_data")
@@ -233,7 +236,9 @@ class TestSysctlConfig(unittest.TestCase):
 
         result = config._sysctl(["-n", "vm.swappiness"])
 
-        assert mock_output.called_with(["sysctl", "-n", "vm.swappiness"])
+        mock_output.assert_called_once_with(
+            ["sysctl", "-n", "vm.swappiness"], stderr=-2, universal_newlines=True
+        )
         assert result == ["1"]
 
     @patch("charms.operator_libs_linux.v0.sysctl.check_output")
@@ -246,7 +251,9 @@ class TestSysctlConfig(unittest.TestCase):
         with self.assertRaises(sysctl.CommandError) as e:
             config._sysctl(["exception"])
 
-        assert mock_output.called_with(["sysctl", "exception"])
+        mock_output.assert_called_once_with(
+            ["sysctl", "exception"], stderr=-2, universal_newlines=True
+        )
         assert e.exception.message == "Error executing '['sysctl', 'exception']': error on command"
 
     @patch("charms.operator_libs_linux.v0.sysctl.Config._sysctl")
@@ -259,7 +266,7 @@ class TestSysctlConfig(unittest.TestCase):
         config._desired_config = {"vm.swappiness": "0"}
         config._apply()
 
-        assert mock_sysctl.called_with(["vm.swappiness=0"])
+        mock_sysctl.assert_called_with(["vm.swappiness=0"])
 
     @patch("charms.operator_libs_linux.v0.sysctl.Config._sysctl")
     @patch("charms.operator_libs_linux.v0.sysctl.Config._load_data")
@@ -272,7 +279,7 @@ class TestSysctlConfig(unittest.TestCase):
         with self.assertRaises(sysctl.ApplyError) as e:
             config._apply()
 
-        assert mock_sysctl.called_with(["vm.swappiness=0"])
+        mock_sysctl.assert_called_with(["vm.swappiness=0"])
         self.assertEqual(e.exception.message, "Unable to set params: ['vm.swappiness']")
 
     @patch("charms.operator_libs_linux.v0.sysctl.Config._sysctl")
@@ -286,7 +293,7 @@ class TestSysctlConfig(unittest.TestCase):
         with self.assertRaises(sysctl.ApplyError) as e:
             config._apply()
 
-        assert mock_sysctl.called_with(["vm.swappiness=0", "net.ipv4.tcp_max_syn_backlog=4096"])
+        mock_sysctl.assert_called_with(["vm.swappiness=0", "net.ipv4.tcp_max_syn_backlog=4096"])
         self.assertEqual(e.exception.message, "Unable to set params: ['vm.swappiness']")
 
     @patch("charms.operator_libs_linux.v0.sysctl.Config._load_data")

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ deps =
     pytest
     coverage[toml]
     -r{toxinidir}/requirements.txt
-    pyfakefs==4.4.0
+    pyfakefs==5.5.0
     dbus-fast==1.90.2
 commands =
     coverage run --source={[vars]lib_dir} \


### PR DESCRIPTION
While testing with python3.12, i had to bump `pyfakefs==5.5.0` due to some changes in `pathlib`

After this adjustment, i found bad tests in `test_sysctl`. 

instead of 

```python
assert my_mock.called_with(...)
```

swapped to 

```python
my_mock.assert_called_once_with(...)
```

Also, it seems codespell now doesn't like `assertIn` so let's start ignoring reasonable words