### PR TITLE
snap.py: fix snap.get optional key

### DIFF
--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -83,7 +83,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 # Regex to locate 7-bit C1 ANSI sequences
@@ -319,7 +319,10 @@ class Snap(object):
                 Default is to return a string.
         """
         if typed:
-            config = json.loads(self._snap("get", ["-d", key]))
+            args = ["-d"]
+            if key:
+                args.append(key)
+            config = json.loads(self._snap("get", args))
             if key:
                 return config.get(key)
             return config

--- a/tests/integration/test_snap.py
+++ b/tests/integration/test_snap.py
@@ -116,6 +116,22 @@ def test_snap_set_and_get_with_typed():
 
     assert lxd.get("criu.enable", typed=True) == "true"
     assert lxd.get("ceph.external", typed=True) == "false"
+    assert lxd.get(None, typed=True) == {
+        "true": True,
+        "false": False,
+        "integer": 1,
+        "float": 2.0,
+        "list": [1, 2.0, True, False, None],
+        "dict": {
+            "true": True,
+            "false": False,
+            "integer": 1,
+            "float": 2.0,
+            "list": [1, 2.0, True, False, None],
+        },
+        "criu": {"enable": "true"},
+        "ceph": {"external": "false"},
+    }
 
 
 def test_snap_set_and_get_untyped():


### PR DESCRIPTION
Fix snap.get method to handle the case where the key is falsy. Treat it as no key provided, which results in the expected behavior to get all values from snap configs.

Fix #124