### PR TITLE
feat: enable juju-systemd-notices to observe snap services

### DIFF
--- a/lib/charms/operator_libs_linux/v0/juju_systemd_notices.py
+++ b/lib/charms/operator_libs_linux/v0/juju_systemd_notices.py
@@ -42,7 +42,7 @@ class ApplicationCharm(CharmBase):
         super().__init__(*args, **kwargs)
 
         # Register services with charm. This adds the events to observe.
-        self._systemd_notices = SystemdNotices(self, Service("snap.slurm.slurmd", alias="slurmd"))
+        self._systemd_notices = SystemdNotices(self, [Service("snap.slurm.slurmd", alias="slurmd")])
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.stop, self._on_stop)
         self.framework.observe(self.on.service_slurmd_started, self._on_slurmd_started)

--- a/lib/charms/operator_libs_linux/v0/juju_systemd_notices.py
+++ b/lib/charms/operator_libs_linux/v0/juju_systemd_notices.py
@@ -91,9 +91,8 @@ import subprocess
 import textwrap
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Mapping, Optional
+from typing import List, Optional, Union
 
-import yaml
 from dbus_fast.aio import MessageBus
 from dbus_fast.constants import BusType, MessageType
 from dbus_fast.errors import DBusError
@@ -113,10 +112,11 @@ LIBPATCH = 1
 
 # juju-systemd-notices charm library dependencies.
 # Charm library dependencies are installed when the consuming charm is packed.
-PYDEPS = ["dbus-fast>=1.90.2", "pyyaml>=6.0.1"]
+PYDEPS = ["dbus-fast>=1.90.2"]
 
 _logger = logging.getLogger(__name__)
 _juju_unit = None
+_observed_services = {}
 _service_states = {}
 _DBUS_CHAR_MAPPINGS = {
     "_5f": "_",  # _ must be first since char mappings contain _.
@@ -161,9 +161,6 @@ class Service:
     name: str
     alias: Optional[str] = None
 
-    def __post_init__(self) -> None:  # noqa D105
-        self.alias = self.alias or self.name
-
 
 class ServiceStartedEvent(EventBase):
     """Event emitted when service has started."""
@@ -176,24 +173,25 @@ class ServiceStoppedEvent(EventBase):
 class SystemdNotices:
     """Observe systemd services on your machine base."""
 
-    def __init__(self, charm: CharmBase, *services: Service) -> None:
+    def __init__(self, charm: CharmBase, services: List[Union[str, Service]]) -> None:
         """Instantiate systemd notices service."""
         self._charm = charm
-        self._services = services
+        self._services = [Service(s) if isinstance(s, str) else s for s in services]
         unit_name = self._charm.unit.name.replace("/", "-")
         self._service_file = Path(f"/etc/systemd/system/juju-{unit_name}-systemd-notices.service")
 
         _logger.debug(
             "Attaching systemd notice events to charm %s", self._charm.__class__.__name__
         )
-        for service in self._services:
-            self._charm.on.define_event(f"service_{service.alias}_started", ServiceStartedEvent)
-            self._charm.on.define_event(f"service_{service.alias}_stopped", ServiceStoppedEvent)
+        for s in self._services:
+            event = s.alias or s.name
+            self._charm.on.define_event(f"service_{event}_started", ServiceStartedEvent)
+            self._charm.on.define_event(f"service_{event}_stopped", ServiceStoppedEvent)
 
     def subscribe(self) -> None:
         """Subscribe charmed operator to observe status of systemd services."""
         self._generate_hooks()
-        self._generate_config()
+        self._generate_service()
         self._start()
 
     def stop(self) -> None:
@@ -205,53 +203,55 @@ class SystemdNotices:
     def _generate_hooks(self) -> None:
         """Generate legacy event hooks for observed systemd services."""
         _logger.debug("Generating systemd notice hooks for %s", self._services)
-        start_hooks = [Path(f"hooks/service-{s.alias}-started") for s in self._services]
-        stop_hooks = [Path(f"hooks/service-{s.alias}-stopped") for s in self._services]
+        events = [s.alias or s.name for s in self._services]
+        start_hooks = [Path(f"hooks/service-{e}-started") for e in events]
+        stop_hooks = [Path(f"hooks/service-{e}-stopped") for e in events]
         for hook in start_hooks + stop_hooks:
             if hook.exists():
                 _logger.debug("Hook %s already exists. Skipping...", hook.name)
             else:
                 hook.symlink_to(self._charm.framework.charm_dir / "dispatch")
 
-    def _generate_config(self) -> None:
-        """Generate watch file for systemd notices daemon."""
-        _logger.debug("Generating watch file for %s", self._services)
-        config = {"services": {s.name: s.alias for s in self._services}}
+    def _generate_service(self) -> None:
+        """Generate systemd service file for notices daemon."""
+        _logger.debug("Generating service file %s", self._service_file.name)
+        if self._service_file.exists():
+            _logger.debug("Overwriting existing service file %s", self._service_file.name)
 
-        config_file = self._charm.framework.charm_dir / "watch.yaml"
-        if config_file.exists():
-            _logger.debug("Overwriting existing watch file %s", config_file.name)
-        config_file.write_text(yaml.dump(config))
-        config_file.chmod(0o600)
+        services = [f"{s.name}={s.alias or s.name}" for s in self._services]
+        self._service_file.write_text(
+            textwrap.dedent(
+                f"""
+                [Unit]
+                Description=Juju systemd notices daemon
+                After=multi-user.target
+
+                [Service]
+                Type=simple
+                Restart=always
+                WorkingDirectory={self._charm.framework.charm_dir}
+                Environment="PYTHONPATH={self._charm.framework.charm_dir / "venv"}"
+                ExecStart=/usr/bin/python3 {__file__} --unit {self._charm.unit.name} {' '.join(services)}
+
+                [Install]
+                WantedBy=multi-user.target
+                """
+            ).strip()
+        )
+
+        _logger.debug(
+            "Service file %s written. Reloading systemd manager configuration",
+            self._service_file.name,
+        )
 
     def _start(self) -> None:
         """Start systemd notices daemon to observe subscribed services."""
         _logger.debug("Starting %s daemon", self._service_file.name)
-        if self._service_file.exists():
-            _logger.debug("Overwriting existing service file %s", self._service_file.name)
-        self._service_file.write_text(
-            textwrap.dedent(
-                f"""
-                    [Unit]
-                    Description=Juju systemd notices daemon
-                    After=multi-user.target
 
-                    [Service]
-                    Type=simple
-                    Restart=always
-                    WorkingDirectory={self._charm.framework.charm_dir}
-                    Environment="PYTHONPATH={self._charm.framework.charm_dir / "venv"}"
-                    ExecStart=/usr/bin/python3 {__file__} {self._charm.unit.name}
-
-                    [Install]
-                    WantedBy=multi-user.target
-                """
-            ).strip()
-        )
-        _logger.debug("Service file %s written. Reloading systemd", self._service_file.name)
+        # Reload systemd manager configuration so that it will pick up notices daemon.
         _daemon_reload()
-        # Notices daemon is enabled so that the service will start even after machine reboot.
-        # This functionality is needed in the event that a charm is rebooted to apply updates.
+
+        # Enable notices daemon to start after machine reboots.
         _enable_service(self._service_file.name)
         _start_service(self._service_file.name)
         _logger.debug("Started %s daemon", self._service_file.name)
@@ -290,16 +290,6 @@ def _dbus_path_to_name(path: str) -> str:
         name = name.replace(key, value)
 
     return name
-
-
-@functools.lru_cache(maxsize=32)
-def _read_config() -> Mapping[str, str]:
-    """Read systemd notices daemon configuration to service names and aliases."""
-    config_file = Path.cwd() / "watch.yaml"
-    _logger.debug("Loading observed services from configuration file %s", config_file)
-
-    with config_file.open("rt") as fin:
-        return yaml.safe_load(fin)["services"]
 
 
 def _systemd_unit_changed(msg: Message) -> bool:
@@ -356,8 +346,8 @@ async def _send_juju_notification(service: str, state: str) -> None:
     if service.endswith(".service"):
         service = service[0:-len(".service")]  # fmt: skip
 
-    watched_services = _read_config()
-    alias = watched_services[service]
+    global _observed_services
+    alias = _observed_services[service]
     event_name = "started" if state == "active" else "stopped"
     hook = f"service-{alias}-{event_name}"
     cmd = ["/usr/bin/juju-exec", _juju_unit, f"hooks/{hook}"]
@@ -411,18 +401,13 @@ async def _async_load_services() -> None:
     that should be watched. Upon finding a service hook it's current ActiveState
     will be queried from systemd to determine it's initial state.
     """
-    global _juju_unit
-
-    watched_services = _read_config()
-    _logger.info("Services from hooks are %s", watched_services)
-    if not watched_services:
-        return
-
     bus = await MessageBus(bus_type=BusType.SYSTEM).connect()
 
     # Loop through all the services and be sure that a new watcher is
     # started for new ones.
-    for service in watched_services.keys():
+    global _observed_services
+    _logger.info("Services to observe are %s", _observed_services)
+    for service in _observed_services:
         # The .service suffix is necessary and will cause lookup failures of the
         # service unit when readying the watcher if absent from the service name.
         service = f"{service}.service"
@@ -498,12 +483,18 @@ def _main():
     """
     parser = argparse.ArgumentParser()
     parser.add_argument("-d", "--debug", action="store_true")
-    parser.add_argument("unit", type=str)
+    parser.add_argument("--unit", type=str)
+    parser.add_argument("services", nargs="*")
     args = parser.parse_args()
 
     # Intentionally set as global.
     global _juju_unit
     _juju_unit = args.unit
+
+    global _observed_services
+    for s in args.services:
+        service, alias = s.split("=")
+        _observed_services[service] = alias
 
     console_handler = logging.StreamHandler()
     if args.debug:

--- a/lib/charms/operator_libs_linux/v0/juju_systemd_notices.py
+++ b/lib/charms/operator_libs_linux/v0/juju_systemd_notices.py
@@ -221,8 +221,7 @@ class SystemdNotices:
         config_file = self._charm.framework.charm_dir / "watch.yaml"
         if config_file.exists():
             _logger.debug("Overwriting existing watch file %s", config_file.name)
-        with config_file.open("wt") as fout:
-            yaml.dump(config, fout)
+        config_file.write_text(yaml.dump(config))
         config_file.chmod(0o600)
 
     def _start(self) -> None:

--- a/lib/charms/operator_libs_linux/v0/juju_systemd_notices.py
+++ b/lib/charms/operator_libs_linux/v0/juju_systemd_notices.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-# Copyright 2023 Canonical Ltd.
+# Copyright 2023-2024 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/charms/operator_libs_linux/v0/juju_systemd_notices.py
+++ b/lib/charms/operator_libs_linux/v0/juju_systemd_notices.py
@@ -108,7 +108,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version.
-LIBPATCH = 1
+LIBPATCH = 2
 
 # juju-systemd-notices charm library dependencies.
 # Charm library dependencies are installed when the consuming charm is packed.

--- a/lib/charms/operator_libs_linux/v0/juju_systemd_notices.py
+++ b/lib/charms/operator_libs_linux/v0/juju_systemd_notices.py
@@ -28,6 +28,7 @@ systemd service and handle events based on the current emitted state:
 
 ```python
 from charms.operator_libs_linux.v0.juju_systemd_notices import (
+    Service,
     ServiceStartedEvent,
     ServiceStoppedEvent,
     SystemdNotices,
@@ -41,7 +42,7 @@ class ApplicationCharm(CharmBase):
         super().__init__(*args, **kwargs)
 
         # Register services with charm. This adds the events to observe.
-        self._systemd_notices = SystemdNotices(self, ["slurmd"])
+        self._systemd_notices = SystemdNotices(self, Service("snap.slurm.slurmd", alias="slurmd"))
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.stop, self._on_stop)
         self.framework.observe(self.on.service_slurmd_started, self._on_slurmd_started)
@@ -58,7 +59,7 @@ class ApplicationCharm(CharmBase):
     def _on_start(self, _: StartEvent) -> None:
         # This will trigger the juju-systemd-notices daemon to
         # emit a `service-slurmd-started` event.
-        systemd.service_start("slurmd")
+        snap.slurmd.enable()
 
     def _on_stop(self, _: StopEvent) -> None:
         # To stop the juju-systemd-notices service running in the background.
@@ -72,7 +73,7 @@ class ApplicationCharm(CharmBase):
 
         # This will trigger the juju-systemd-notices daemon to
         # emit a `service-slurmd-stopped` event.
-        systemd.service_stop("slurmd")
+        snap.slurmd.stop()
 
     def _on_slurmd_stopped(self, _: ServiceStoppedEvent) -> None:
         self.unit.status = BlockedStatus("slurmd not running")

--- a/lib/charms/operator_libs_linux/v0/juju_systemd_notices.py
+++ b/lib/charms/operator_libs_linux/v0/juju_systemd_notices.py
@@ -316,7 +316,6 @@ def _systemd_unit_changed(msg: Message) -> bool:
     if "ActiveState" not in properties:
         return False
 
-    global _service_states
     if service not in _service_states:
         _logger.debug("Dropping event for unwatched service: %s", service)
         return False
@@ -346,7 +345,6 @@ async def _send_juju_notification(service: str, state: str) -> None:
     if service.endswith(".service"):
         service = service[0:-len(".service")]  # fmt: skip
 
-    global _observed_services
     alias = _observed_services[service]
     event_name = "started" if state == "active" else "stopped"
     hook = f"service-{alias}-{event_name}"
@@ -405,7 +403,6 @@ async def _async_load_services() -> None:
 
     # Loop through all the services and be sure that a new watcher is
     # started for new ones.
-    global _observed_services
     _logger.info("Services to observe are %s", _observed_services)
     for service in _observed_services:
         # The .service suffix is necessary and will cause lookup failures of the
@@ -491,7 +488,6 @@ def _main():
     global _juju_unit
     _juju_unit = args.unit
 
-    global _observed_services
     for s in args.services:
         service, alias = s.split("=")
         _observed_services[service] = alias

--- a/tests/integration/juju_systemd_notices/notices-charm/actions.yaml
+++ b/tests/integration/juju_systemd_notices/notices-charm/actions.yaml
@@ -1,5 +1,0 @@
-# Copyright 2023 Canonical Ltd.
-# See LICENSE file for licensing details.
-
-stop-service:
-  description: Stop internal test service inside charm

--- a/tests/integration/juju_systemd_notices/notices-charm/charmcraft.yaml
+++ b/tests/integration/juju_systemd_notices/notices-charm/charmcraft.yaml
@@ -1,5 +1,11 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2023-2024 Canonical Ltd.
 # See LICENSE file for licensing details.
+
+name: juju-systemd-notices
+description: |
+  Test charm used for the juju_systemd_notices charm library integration tests.
+summary: |
+  A charm with a minimal daemon for testing the juju-systemd-notices charm library.
 
 type: charm
 bases:
@@ -9,3 +15,8 @@ bases:
     run-on:
     - name: ubuntu
       channel: "22.04"
+
+actions:
+  stop-service:
+    description: Stop internal test service inside charm
+

--- a/tests/integration/juju_systemd_notices/notices-charm/metadata.yaml
+++ b/tests/integration/juju_systemd_notices/notices-charm/metadata.yaml
@@ -1,8 +1,0 @@
-# Copyright 2023 Canonical Ltd.
-# See LICENSE file for licensing details.
-
-name: juju-systemd-notices
-description: |
-  Test charm used for the juju_systemd_notices charm library integration tests.
-summary: |
-  A charm with a minimal daemon for testing the juju-systemd-notices charm library.

--- a/tests/integration/juju_systemd_notices/notices-charm/src/charm.py
+++ b/tests/integration/juju_systemd_notices/notices-charm/src/charm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2023 Canonical Ltd.
+# Copyright 2023-2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Minimal charm for testing the juju_systemd_notices charm library.
@@ -12,6 +12,7 @@ import logging
 import charms.operator_libs_linux.v1.systemd as systemd
 import daemon
 from charms.operator_libs_linux.v0.juju_systemd_notices import (
+    Service,
     ServiceStartedEvent,
     ServiceStoppedEvent,
     SystemdNotices,
@@ -29,7 +30,7 @@ class NoticesCharm(CharmBase):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-        self._systemd_notices = SystemdNotices(self, ["test"])
+        self._systemd_notices = SystemdNotices(self, Service("test"))
         event_handler_bindings = {
             self.on.install: self._on_install,
             self.on.start: self._on_start,

--- a/tests/integration/juju_systemd_notices/notices-charm/src/charm.py
+++ b/tests/integration/juju_systemd_notices/notices-charm/src/charm.py
@@ -12,7 +12,6 @@ import logging
 import charms.operator_libs_linux.v1.systemd as systemd
 import daemon
 from charms.operator_libs_linux.v0.juju_systemd_notices import (
-    Service,
     ServiceStartedEvent,
     ServiceStoppedEvent,
     SystemdNotices,
@@ -30,7 +29,7 @@ class NoticesCharm(CharmBase):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-        self._systemd_notices = SystemdNotices(self, Service("test"))
+        self._systemd_notices = SystemdNotices(self, ["test"])
         event_handler_bindings = {
             self.on.install: self._on_install,
             self.on.start: self._on_start,

--- a/tests/unit/test_juju_systemd_notices.py
+++ b/tests/unit/test_juju_systemd_notices.py
@@ -7,7 +7,6 @@
 import argparse
 import subprocess
 import unittest
-from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 from charms.operator_libs_linux.v0.juju_systemd_notices import (
@@ -46,7 +45,9 @@ class MockNoticesCharm(CharmBase):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-        self.notices = SystemdNotices(self, Service("foobar"), Service("snap.test.service", alias="service"))
+        self.notices = SystemdNotices(
+            self, Service("foobar"), Service("snap.test.service", alias="service")
+        )
         event_handler_bindings = {
             self.on.install: self._on_install,
             self.on.stop: self._on_stop,
@@ -213,7 +214,10 @@ class TestJujuSystemdNoticesDaemon(unittest.IsolatedAsyncioTestCase):
         ):
             self.assertTrue(_systemd_unit_changed(mock_message))
 
-    @patch("charms.operator_libs_linux.v0.juju_systemd_notices._read_config", return_value={"foobar": "foobar"})
+    @patch(
+        "charms.operator_libs_linux.v0.juju_systemd_notices._read_config",
+        return_value={"foobar": "foobar"},
+    )
     @patch("charms.operator_libs_linux.v0.juju_systemd_notices._juju_unit", "foobar/0")
     @patch("asyncio.create_subprocess_exec")
     async def test_send_juju_notification(self, mock_subcmd, *_) -> None:

--- a/tests/unit/test_juju_systemd_notices.py
+++ b/tests/unit/test_juju_systemd_notices.py
@@ -7,6 +7,7 @@
 import argparse
 import subprocess
 import unittest
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 from charms.operator_libs_linux.v0.juju_systemd_notices import (
@@ -98,7 +99,12 @@ class TestJujuSystemdNoticesCharmAPI(unittest.TestCase):
     def test_generate_config(self, mock_exists) -> None:
         """Test that watch configuration file is generated correctly."""
         with Patcher() as patcher:
-            patcher.fs.create_file("no-disk-path/watch.yaml")
+            # Set charm_dir to "/" because mocked charm_dir default
+            # `no-disk-path` does not exist within the fake filesystem.
+            # Tried creating `no-disk-path` in the fake filesystem, but
+            # the mocked objects could not find it.
+            self.harness.charm.framework.charm_dir = Path("/")
+            patcher.fs.create_file("watch.yaml")
 
             # Scenario 1 - Generate success but no pre-existing watch configuration.
             mock_exists.return_value = False

--- a/tests/unit/test_juju_systemd_notices.py
+++ b/tests/unit/test_juju_systemd_notices.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 from charms.operator_libs_linux.v0.juju_systemd_notices import (
+    Service,
     ServiceStartedEvent,
     ServiceStoppedEvent,
     SystemdNotices,
@@ -29,6 +30,14 @@ from dbus_fast.errors import DBusError
 from ops.charm import CharmBase, InstallEvent, StopEvent
 from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
+from pyfakefs.fake_filesystem_unittest import Patcher
+
+mock_watch_config = """
+---
+services:
+  foobar: foobar
+  snap.test.service: service
+"""
 
 
 class MockNoticesCharm(CharmBase):
@@ -37,7 +46,7 @@ class MockNoticesCharm(CharmBase):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-        self._systemd_notices = SystemdNotices(self, ["foobar"])
+        self.notices = SystemdNotices(self, Service("foobar"), Service("snap.test.service", alias="service"))
         event_handler_bindings = {
             self.on.install: self._on_install,
             self.on.stop: self._on_stop,
@@ -49,11 +58,11 @@ class MockNoticesCharm(CharmBase):
 
     def _on_install(self, _: InstallEvent) -> None:
         """Subscribe to foobar service to watch for events."""
-        self._systemd_notices.subscribe()
+        self.notices.subscribe()
 
     def _on_stop(self, _: StopEvent) -> None:
         """Stop watching foobar service as machine is removed."""
-        self._systemd_notices.stop()
+        self.notices.stop()
 
     def _on_foobar_started(self, _: ServiceStartedEvent) -> None:
         """Set status to active after systemctl marks service as active."""
@@ -72,23 +81,57 @@ class TestJujuSystemdNoticesCharmAPI(unittest.TestCase):
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
 
+    @patch("pathlib.Path.symlink_to")
+    @patch("pathlib.Path.exists")
+    def test_generate_hooks(self, mock_exists, _) -> None:
+        """Test that legacy event hooks for observed services are created correctly."""
+        # Scenario 1 - Generate success but no pre-existing hooks.
+        mock_exists.return_value = False
+        self.harness.charm.notices._generate_hooks()
+
+        # Scenario 2 - Generate success but pre-existing hooks.
+        mock_exists.return_value = True
+        self.harness.charm.notices._generate_hooks()
+
+    @patch("pathlib.Path.exists")
+    def test_generate_config(self, mock_exists) -> None:
+        """Test that watch configuration file is generated correctly."""
+        with Patcher() as patcher:
+            patcher.fs.create_file("no-disk-path/watch.yaml")
+
+            # Scenario 1 - Generate success but no pre-existing watch configuration.
+            mock_exists.return_value = False
+            self.harness.charm.notices._generate_config()
+
+            # Scenario 2 - Generate success but pre-existing watch configuration.
+            mock_exists.return_value = True
+            self.harness.charm.notices._generate_config()
+
     @patch("pathlib.Path.write_text")
     @patch("pathlib.Path.symlink_to")
     @patch("subprocess.check_output")
     @patch("pathlib.Path.exists")
-    def test_subscribe(self, mock_exists, mock_subp, *_) -> None:
+    def test_start(self, mock_exists, mock_subp, *_) -> None:
+        """Test that start method correctly starts notices daemon."""
         # Scenario 1 - Subscribe success but no pre-existing service file.
         mock_exists.return_value = False
-        self.harness.charm.on.install.emit()
+        self.harness.charm.notices._start()
 
         # Scenario 2 - Subscribe success and pre-existing service file.
         mock_exists.return_value = True
-        self.harness.charm.on.install.emit()
+        self.harness.charm.notices._start()
 
         # Scenario 3 - Subscribe success but systemctl fails to start notices daemon.
         mock_subp.side_effect = subprocess.CalledProcessError(1, "systemctl start foobar")
         with self.assertRaises(subprocess.CalledProcessError):
-            self.harness.charm.on.install.emit()
+            self.harness.charm.notices._start()
+
+    @patch("charms.operator_libs_linux.v0.juju_systemd_notices.SystemdNotices._generate_hooks")
+    @patch("charms.operator_libs_linux.v0.juju_systemd_notices.SystemdNotices._generate_config")
+    @patch("charms.operator_libs_linux.v0.juju_systemd_notices.SystemdNotices._start")
+    def test_subscribe(self, *_) -> None:
+        """Test `subscribe` method."""
+        self.harness.charm.on.install.emit()
 
     @patch("subprocess.check_output")
     def test_stop(self, *_) -> None:
@@ -170,21 +213,22 @@ class TestJujuSystemdNoticesDaemon(unittest.IsolatedAsyncioTestCase):
         ):
             self.assertTrue(_systemd_unit_changed(mock_message))
 
+    @patch("charms.operator_libs_linux.v0.juju_systemd_notices._read_config", return_value={"foobar": "foobar"})
     @patch("charms.operator_libs_linux.v0.juju_systemd_notices._juju_unit", "foobar/0")
     @patch("asyncio.create_subprocess_exec")
-    async def test_send_juju_notification(self, mock_subp, *_) -> None:
+    async def test_send_juju_notification(self, mock_subcmd, *_) -> None:
         # Scenario 1 - .service in service name and notification succeeds.
         mock_p = AsyncMock()
         mock_p.wait.return_value = None
         mock_p.returncode = 0
-        mock_subp.return_value = mock_p
+        mock_subcmd.return_value = mock_p
         await _send_juju_notification("foobar.service", "active")
 
         # Scenario 2 - No .service in name and state is stopped but notification fails.
         mock_p = AsyncMock()
         mock_p.wait.return_value = None
         mock_p.returncode = 1
-        mock_subp.return_value = mock_p
+        mock_subcmd.return_value = mock_p
         await _send_juju_notification("foobar", "inactive")
 
     async def test_get_service_state(self) -> None:
@@ -206,33 +250,22 @@ class TestJujuSystemdNoticesDaemon(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(state, "unknown")
 
     @patch("charms.operator_libs_linux.v0.juju_systemd_notices._get_service_state")
-    @patch("pathlib.Path.iterdir")
-    @patch("pathlib.Path.exists")
-    async def test_async_load_services(self, mock_exists, mock_iterdir, mock_state) -> None:
-        # Scenario 1 - Hooks dir does not exist.
-        mock_exists.return_value = False
-        self.assertIsNone(await _async_load_services())
+    @patch("charms.operator_libs_linux.v0.juju_systemd_notices._read_config")
+    async def test_async_load_services(self, mock_config, mock_state) -> None:
+        mock_config.return_value = {}
+        await _async_load_services()
 
-        # Scenario 2 - There are no services to watch.
-        mock_exists.return_value = True
-        mock_iterdir.return_value = []
-        self.assertIsNone(await _async_load_services())
-
-        # Scenario 3 - Desired outcome (services are subscribed to for watching).
-        mock_exists.return_value = True
-        mock_iterdir.return_value = [
-            Path("service-foobar-started"),
-            Path("service-foobar-stopped"),
-            Path("dispatch"),  # Ensure that unmatched hooks are ignored/not registered.
-        ]
+        mock_config.return_value = {"foobar": "foobar"}
         mock_state.return_value = "active"
-        self.assertIsNone(await _async_load_services())
+        await _async_load_services()
 
     @patch("pathlib.Path.exists", return_value=False)
     @patch("asyncio.Event.wait")
     async def test_juju_systemd_notices_daemon(self, *_) -> None:
         # Desired outcome is that _juju_systemd_notices does not fail to start.
-        await _juju_systemd_notices_daemon()
+        with Patcher() as patcher:
+            patcher.fs.create_file("watch.yaml", contents=mock_watch_config)
+            await _juju_systemd_notices_daemon()
 
     @patch("charms.operator_libs_linux.v0.juju_systemd_notices._juju_systemd_notices_daemon")
     @patch("argparse.ArgumentParser.parse_args")

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ deps =
     black
     ruff
 commands =
-    ruff --fix {[vars]all_dir}
+    ruff check --fix {[vars]all_dir}
     black {[vars]all_dir}
 
 [testenv:lint]
@@ -43,7 +43,7 @@ deps =
     codespell
 commands =
     codespell {toxinidir}
-    ruff {[vars]all_dir}
+    ruff check {[vars]all_dir}
     black --check --diff {[vars]all_dir}
 
 [testenv:unit]


### PR DESCRIPTION
Fixes #126 

This pull request enables support for observing snap services using the `juju-systemd-notices` charm library.

The key change in this pull request is modifying how the notices daemon configures how it observes services on the machine. Rather than configure which services to observe by reading the `hooks` directory, the daemon instead reads a _watch.yaml_ file in the charm directory. Here's what the _watch.yaml_ file would look like in a deployed charm using the notices daemon:

```yaml
---
snap.slurm.slurmd: slurmd
snap.slurm.munged: munged
```

Originally, `juju-systemd-notices` used a regex that parsed hook names to determine which services to observe with the notices daemon. This approach worked until we needed to start working with nested services - e.g. have `.` in the service name like `snap.slurm.slurmd` - so we had to find a new way to configure how to observe services, but also ensure that the correct hook would be fired by the charm. We decided to use a key value approach where the key is the service name to observe over DBus, and the value is the valid event name alias used to trigger the start/stop events.

Now, when the notices daemon captures the event, it uses the configured alias to determine which hook to fire, but can still watch DBus using the correct service name.

### Misc.

1. I tried using systemd unit aliases, but that didn't work. DBus will "follow the symlink" to the original service name - e.g. `snap.slurm.slurmd` - and not the unit alias `slurmd`.
2. We had to update _tox.ini_ because `ruff` now requires the subcommand `check` to perform linting actions.
3. We likely need to bump the LIBAPI version since the `SystemdNotices` __init__ constructor now takes a variable amount of `Service` objects rather than a `List[str]`. We used a `Service` dataclass since it made it easy to provide service name aliases and set a default alias if none was provided by the charm author.