### PR TITLE
Fail and retry on "Some index files failed to download"

### DIFF
--- a/lib/charms/operator_libs_linux/v0/apt.py
+++ b/lib/charms/operator_libs_linux/v0/apt.py
@@ -122,7 +122,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 
 VALID_SOURCE_TYPES = ("deb", "deb-src")

--- a/lib/charms/operator_libs_linux/v0/apt.py
+++ b/lib/charms/operator_libs_linux/v0/apt.py
@@ -837,7 +837,7 @@ def remove_package(
 
 def update() -> None:
     """Update the apt cache via `apt-get update`."""
-    subprocess.run(["apt-get", "update"], capture_output=True, check=True)
+    subprocess.run(["apt-get", "update", "--error-on=any"], capture_output=True, check=True)
 
 
 def import_key(key: str) -> str:

--- a/tests/unit/test_apt.py
+++ b/tests/unit/test_apt.py
@@ -511,7 +511,9 @@ class TestAptBareMethods(unittest.TestCase):
             apt_cache_aisleriot,
         ]
         pkg = apt.add_package("aisleriot")
-        mock_subprocess.assert_any_call(["apt-get", "update"], capture_output=True, check=True)
+        mock_subprocess.assert_any_call(
+            ["apt-get", "update", "--error-on=any"], capture_output=True, check=True
+        )
         self.assertEqual(pkg.name, "aisleriot")
         self.assertEqual(pkg.present, True)
 
@@ -527,7 +529,9 @@ class TestAptBareMethods(unittest.TestCase):
         ] * 2  # Double up for the retry after update
         with self.assertRaises(apt.PackageError) as ctx:
             apt.add_package("nothere")
-        mock_subprocess.assert_any_call(["apt-get", "update"], capture_output=True, check=True)
+        mock_subprocess.assert_any_call(
+            ["apt-get", "update", "--error-on=any"], capture_output=True, check=True
+        )
         self.assertEqual("<charms.operator_libs_linux.v0.apt.PackageError>", ctx.exception.name)
         self.assertIn("Failed to install packages: nothere", ctx.exception.message)
 


### PR DESCRIPTION
In scripting apt operations, adding `--error-on=any` to `apt-get update` is necessary to capture erros like "Some index files failed to download". Otherwise, charms move onto package installations with a stale index.

equivalent to: https://github.com/juju/charm-helpers/pull/911
ref: https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1693900