### PR TITLE
fix: Task status can be `Do` and should not raise an error.

### DIFF
--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -84,7 +84,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 9
 
 
 # Regex to locate 7-bit C1 ANSI sequences

--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -787,7 +787,7 @@ class SnapClient:
             status = response["status"]
             if status == "Done":
                 return response.get("data")
-            if status == "Doing":
+            if status == "Doing" or status == "Do":
                 time.sleep(0.1)
                 continue
             if status == "Wait":

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -701,6 +701,7 @@ class TestSocketClient(unittest.TestCase):
             shutdown()
 
     def test_wait_changes(self):
+        change_started = False
         change_finished = False
 
         def _request_raw(
@@ -711,6 +712,7 @@ class TestSocketClient(unittest.TestCase):
             data: bytes = None,
         ) -> typing.IO[bytes]:
             nonlocal change_finished
+            nonlocal change_started
             if method == "PUT" and path == "snaps/test/conf":
                 return io.BytesIO(
                     json.dumps(
@@ -720,6 +722,36 @@ class TestSocketClient(unittest.TestCase):
                             "status": "Accepted",
                             "result": None,
                             "change": "97",
+                        }
+                    ).encode("utf-8")
+                )
+            if method == "GET" and path == "changes/97" and not change_started:
+                change_started = True
+                return io.BytesIO(
+                    json.dumps(
+                        {
+                            "type": "sync",
+                            "status-code": 200,
+                            "status": "OK",
+                            "result": {
+                                "id": "97",
+                                "kind": "configure-snap",
+                                "summary": 'Change configuration of "test" snap',
+                                "status": "Do",
+                                "tasks": [
+                                    {
+                                        "id": "1028",
+                                        "kind": "run-hook",
+                                        "summary": 'Run configure hook of "test" snap',
+                                        "status": "Do",
+                                        "progress": {"label": "", "done": 0, "total": 1},
+                                        "spawn-time": "2024-11-28T20:02:47.498399651+00:00",
+                                        "data": {"affected-snaps": ["test"]},
+                                    }
+                                ],
+                                "ready": False,
+                                "spawn-time": "2024-11-28T20:02:47.49842583+00:00",
+                            },
                         }
                     ).encode("utf-8")
                 )


### PR DESCRIPTION
## Description

This PR fixes the issue #139 .
The task status can be `Do` and should not be considered an error ([see here](https://snapcraft.io/docs/snapd-rest-api#heading--changes) in the subsection 'Task Fields').

This status means that the task is ready to start but hasn't started yet.

## How is it tested?

I have added a case in the unit testing of the SnapClient.
