### PR TITLE
tests: fix flaky snap test by adding multiple retries

### DIFF
--- a/tests/integration/test_snap.py
+++ b/tests/integration/test_snap.py
@@ -66,11 +66,18 @@ def test_snap_refresh():
 def test_snap_set_and_get_with_typed():
     cache = snap.SnapCache()
     lxd = cache["lxd"]
-    try:
-        lxd.ensure(snap.SnapState.Latest, channel="latest")
-    except snap.SnapError:
-        time.sleep(60)
-        lxd.ensure(snap.SnapState.Latest, channel="latest")
+
+    def try_ensure_snap(retries: int) -> None:
+        try:
+            lxd.ensure(snap.SnapState.Latest, channel="latest")
+        except snap.SnapError:
+            if retries <= 0:
+                raise
+            time.sleep(20)
+            try_ensure_snap(retries=retries - 1)
+
+    try_ensure_snap(retries=10)
+
     configs = {
         "true": True,
         "false": False,


### PR DESCRIPTION
One test, `test_snap_set_and_get_with_typed`, often [fails](https://github.com/canonical/operator-libs-linux/actions/runs/12043896518/job/33580021129) -- maybe 50% of the time. It fails when trying to ensure that the `lxd` snap is present on the latest version, raising a `SnapError` with the  message 'Waiting for "snap.lxd.daemon.service" to stop'.

The existing code catches this once, waits 60 seconds and retries. Since the test often passes, this must sometimes be sufficient, so this PR simply uses slightly more robust retry logic -- retrying up to 10 times with 20 seconds in between each attempt. In [5/5 CI runs](https://github.com/james-garner-canonical/operator-libs-linux/actions/runs/12643899480/job/35232205555?pr=4), this passed every time .

As a future CI improvement, it would be nice to improve test turnaround time by using snaps at versions that are already installed in the runner images as much as possible.

Resolves #123 
Resolves #133