### PR TITLE
ci: use ubuntu-latest; bump checkout and python versions (following ops)

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -6,52 +6,61 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - name: Install dependencies
-        run: python3 -m pip install tox
+        uses: actions/checkout@v4
+      - name: Set up Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install tox
+        run: pip install tox~=4.2
       - name: Run linters
         run: tox -e lint
   unit-test:
     name: Unit tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.8", "3.10", "3.12"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: python -m pip install tox
+      - name: Install tox
+        run: pip install tox~=4.2
       - name: Run tests
         run: tox -e unit
   integration-test-ubuntu:
     name: Ubuntu integration tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - name: Install dependencies
-        run: sudo python -m pip install tox
+        uses: actions/checkout@v4
+      - name: Set up Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      # tests must be run as root because they configure the system
+      - name: Install tox
+        run: sudo apt install tox
       - name: Run integration tests for Ubuntu
-        # tests must be run as root because they configure the system
         run: sudo tox -e integration-ubuntu
   integration-test-juju-systemd-notices:
     name: Juju systemd notices integration tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
-          juju-channel: 3.1/stable
+          juju-channel: 3.6/stable
       - name: Run integration tests (juju-systemd-notices)
         run: tox run -e integration-juju-systemd-notices


### PR DESCRIPTION
This PR updates the `build-and-test` workflow to run on `ubuntu-latest` instead of `ubuntu-22.04`, following `ops`.

It also bumps the versions on the `checkout` and `setup-python` actions accordingly, and pins the `tox` version following `ops`.

For the integration tests, which require running `tox` as `root`, we install `tox` via `apt`.

Also bump the `juju` version from `3.1` to `3.6` since it's the LTS release.