### PR TITLE
ci: update linting (following ops)

### DIFF
--- a/lib/charms/operator_libs_linux/v0/apt.py
+++ b/lib/charms/operator_libs_linux/v0/apt.py
@@ -806,7 +806,7 @@ def _add(
 
 
 def remove_package(
-    package_names: Union[str, List[str]]
+    package_names: Union[str, List[str]],
 ) -> Union[DebianPackage, List[DebianPackage]]:
     """Remove package(s) from the system.
 
@@ -1033,7 +1033,8 @@ class DebianRepository:
                     add-apt-repository --no-update --sourceslist="$repo_line"
         """
         repo = RepositoryMapping._parse(  # pyright: ignore[reportPrivateUsage]
-            repo_line, filename="UserInput"  # temp filename
+            repo_line,
+            filename="UserInput",  # temp filename
         )
         repo.filename = repo._make_filename()
         if write_file:

--- a/lib/charms/operator_libs_linux/v0/apt.py
+++ b/lib/charms/operator_libs_linux/v0/apt.py
@@ -238,7 +238,7 @@ class DebianPackage:
         Args:
           command: the command given to `apt-get`
           package_names: a package name or list of package names to operate on
-          optargs: an (Optional) list of additioanl arguments
+          optargs: an (Optional) list of additional arguments
 
         Raises:
           PackageError if an error is encountered
@@ -1143,7 +1143,7 @@ class DebianRepository:
           keyid: An 8, 16 or 40 hex digit keyid to find a key for
 
         Returns:
-          A string contining key material for the specified GPG key id
+          A string containing key material for the specified GPG key id
 
 
         Raises:
@@ -1693,7 +1693,7 @@ def _deb822_options_to_repos(
             msg = (
                 "Since 'Suites' (line {suites_line}) specifies"
                 " a path relative to  'URIs' (line {uris_line}),"
-                " 'Components' must be  ommitted."
+                " 'Components' must be  omitted."
             ).format(
                 suites_line=line_numbers.get("Suites"),
                 uris_line=line_numbers.get("URIs"),

--- a/lib/charms/operator_libs_linux/v0/sysctl.py
+++ b/lib/charms/operator_libs_linux/v0/sysctl.py
@@ -52,7 +52,7 @@ class MyCharm(CharmBase):
         self.framework.observe(self.on.remove, self._on_remove)
 
     def _on_install(self, _):
-        # Altenatively, read the values from a template
+        # Alternatively, read the values from a template
         sysctl_data = {"net.ipv4.tcp_max_syn_backlog": "4096"}}
 
         try:

--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -893,7 +893,7 @@ class SnapCache(Mapping):
 
     @property
     def snapd_installed(self) -> bool:
-        """Check whether snapd has been installled on the system."""
+        """Check whether snapd has been installed on the system."""
         return os.path.isfile("/usr/bin/snap")
 
     def _load_available_snaps(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,33 +10,191 @@ show_missing = true
 minversion = "6.0"
 log_cli_level = "INFO"
 
-# Formatting tools configuration
-[tool.black]
-line-length = 99
-target-version = ["py38"]
-
 # Linting tools configuration
 [tool.ruff]
 line-length = 99
+target-version = "py38"
 extend-exclude = ["__pycache__", "*.egg_info", "htmlcov"]
 
+# Ruff formatter configuration
+[tool.ruff.format]
+quote-style = "preserve"  # FIXME: use double for consistency with current codebase convention
+
 [tool.ruff.lint]
-select = ["E", "W", "F", "C", "N", "D", "I001"]
-extend-ignore = [
-    "D203",
-    "D204",
-    "D213",
-    "D215",
-    "D400",
-    "D404",
-    "D406",
-    "D407",
-    "D408",
-    "D409",
-    "D413",
+select = [
+    # flake8-builtins
+    "A",
+    # flake8-bugbear
+    "B",
+    # pyflakes-docstrings
+    "D",
+    # conventional names
+    "C",
+    # flake8-copyright
+    # FIXME: enable when we switch to --preview for format
+    # "CPY",
+    # Pycodestyle (error)
+    "E",
+    # Pyflakes
+    "F",
+    # isort
+    "I001",
+    # pep8-naming
+    "N",
+    # Perflint
+    "PERF",
+    # Ruff specific
+    "RUF",
+    # flake8-bandit
+    "S",
+    # flake8-simplify
+    "SIM",
+    # pyupgrade
+    "UP",
+    # Pycodestyle (warning)
+    "W",
+    # flake8-2020
+    "YTT",
 ]
-ignore = ["E501", "D107"]
-per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
+ignore = [
+    # Use from err or from None explicitly
+    # FIXME
+    "B904",
+    # Missing docstring in magic method
+    "D105",
+    # Missing docstring in `__init__`
+    "D107",
+    # too many leading # before block comment
+    # FIXME
+    "E266",
+    # Line too long
+    # FIXME
+    "E501",
+    # try/except inside loop
+    # FIXME: lift or noqa individually as appropriate
+    "PERF203",
+    # Unused noqa
+    # FIXME
+    "RUF100",
+    # use unpacking instead of concatenation with lists
+    # FIXME
+    "RUF005",
+    # implicit Optional in typing
+    # FIXME: typing
+    "RUF013",
+    # Use of `assert` detected
+    "S101",
+    # `subprocess` module is possibly insecure
+    "S404",
+    # subprocess: check for execution of untrusted input
+    # FIXME: individually validate or noqa these
+    "S603",
+    # subprocess: starting process with a partial executable path
+    # FIXME: individually validate or noqa these
+    "S607",
+    # Return condition directly, prefer readability.
+    "SIM103",
+    # Use contextlib.suppress() instead of try/except: pass
+    "SIM105",
+    # Use a single `with` statement with multiple contexts instead of nested `with` statements
+    "SIM117",
+    # Unnecessary open mode parameters
+    # FIXME
+    "UP015",
+    # prefer capture_output over using stdout+stderr with PIPE
+    # FIXME
+    "UP022",
+    # use {} {} instead if {0} {1} if they're in order
+    # FIXME: migrate to fstrings
+    "UP030",
+    # Use fstrings instead of `format`
+    # FIXME: migrate to fstrings
+    "UP032",
+]
+
+[tool.ruff.lint.pyupgrade]
+# Preserve types, even if a file imports `from __future__ import annotations`.
+# Since we target py 3.8, we want to keep using List[str] and Optional[str]
+keep-runtime-typing = true
+
+[tool.ruff.lint.per-file-ignores]
+"lib/charms/operator_libs_linux/v0/apt.py" = [
+    # Use a context manager for opening files
+    # FIXME: false positive, noqa it
+    "SIM115",
+]
+"lib/charms/operator_libs_linux/v0/grub.py" = [
+    # Probably insecure usage of temporary file or directory under /tmp
+    # FIXME: use stdlib tempfile
+    "S108",
+]
+"lib/charms/operator_libs_linux/v0/juju_systemd_notices.py" = [
+    # unqualified noqa
+    # FIXME
+    "RUF100",
+    # Store a reference to the return value of `asyncio.create_task`
+    # FIXME: investigate
+    "RUF006",
+]
+"lib/charms/operator_libs_linux/v2/snap.py" = [
+    # mutable default argument
+    # FIXME
+    "B006",
+    # audit url open for permitted schemes
+    # FIXME: probably noqa manually
+    "S310",
+    # using None explicitly with get
+    # FIXME
+    "SIM910",
+    # inheriting from object
+    # FIXME
+    "UP004",
+    # use text instead of universal_newlines with subprocess.run
+    # FIXME
+    "UP021",
+    # catch OSError instead of alias IOError
+    # FIXME
+    "UP024",
+]
+"tests/*" = [
+    # All documentation linting.
+    "D",
+    # "Useless" expression.
+    "B018",
+    # Line too long (lots of raw data for comparisons)
+    "E501",
+    # Use of `assert` detected
+    "S101",
+    # Hard-coded password string.
+    "S105",
+    # Hard-coded password function argument.
+    "S106",
+    # Probably insecure usage of temporary file or directory (e.g. /tmp/bad.list)
+    "S108",
+]
+"tests/integration/test_passwd.py" = [
+    # function call with 'truthy' `shell` parameter
+    # FIXME
+    "S604",
+]
+"tests/integration/test_grub.py" = [
+    # detected, some yoda conditionals were
+    # FIXME
+    "SIM300",
+]
+"tests/unit/test_repo.py" = [
+    # use context manager for opening files
+    # FIXME
+    "SIM115",
+]
+"tests/unit/test_sysctl.py" = [
+    # combine if branches using logical or
+    # FIXME
+    "SIM114",
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
 
 [tool.ruff.lint.mccabe]
 max-complexity = 14
@@ -44,3 +202,4 @@ max-complexity = 14
 [tool.codespell]
 skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.vscode,.coverage,htmlcov"
 ignore-words-list = "assertIn"
+quiet-level = 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ target-version = ["py38"]
 # Linting tools configuration
 [tool.ruff]
 line-length = 99
+extend-exclude = ["__pycache__", "*.egg_info", "htmlcov"]
+
+[tool.ruff.lint]
 select = ["E", "W", "F", "C", "N", "D", "I001"]
 extend-ignore = [
     "D203",
@@ -33,10 +36,9 @@ extend-ignore = [
     "D413",
 ]
 ignore = ["E501", "D107"]
-extend-exclude = ["__pycache__", "*.egg_info", "htmlcov"]
 per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 14
 
 [tool.codespell]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 # Testing tools configuration
 [tool.coverage.run]
 branch = true
+dynamic_context = "test_function"
 
 [tool.coverage.report]
 show_missing = true
@@ -32,12 +33,12 @@ extend-ignore = [
     "D413",
 ]
 ignore = ["E501", "D107"]
-extend-exclude = ["__pycache__", "*.egg_info"]
+extend-exclude = ["__pycache__", "*.egg_info", "htmlcov"]
 per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
 
 [tool.ruff.mccabe]
 max-complexity = 14
 
 [tool.codespell]
-skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.vscode,.coverage"
+skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.vscode,.coverage,htmlcov"
 ignore-words-list = "assertIn"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,13 +56,26 @@ select = [
     "YTT",
 ]
 ignore = [
-    # Use from err or from None explicitly
-    # FIXME
-    "B904",
+    # mccabe
+    "C90",
     # Missing docstring in magic method
     "D105",
     # Missing docstring in `__init__`
     "D107",
+    # Use of `assert` detected
+    "S101",
+    # `subprocess` module is possibly insecure
+    "S404",
+    # Return condition directly, prefer readability.
+    "SIM103",
+    # Use contextlib.suppress() instead of try/except: pass
+    "SIM105",
+    # Use a single `with` statement with multiple contexts instead of nested `with` statements
+    "SIM117",
+
+    # Use from err or from None explicitly
+    # FIXME
+    "B904",
     # too many leading # before block comment
     # FIXME
     "E266",
@@ -81,22 +94,12 @@ ignore = [
     # implicit Optional in typing
     # FIXME: typing
     "RUF013",
-    # Use of `assert` detected
-    "S101",
-    # `subprocess` module is possibly insecure
-    "S404",
     # subprocess: check for execution of untrusted input
     # FIXME: individually validate or noqa these
     "S603",
     # subprocess: starting process with a partial executable path
     # FIXME: individually validate or noqa these
     "S607",
-    # Return condition directly, prefer readability.
-    "SIM103",
-    # Use contextlib.suppress() instead of try/except: pass
-    "SIM105",
-    # Use a single `with` statement with multiple contexts instead of nested `with` statements
-    "SIM117",
     # Unnecessary open mode parameters
     # FIXME
     "UP015",
@@ -195,9 +198,6 @@ keep-runtime-typing = true
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 
-[tool.ruff.lint.mccabe]
-max-complexity = 14
-
 [tool.codespell]
 skip = [
     ".git",
@@ -213,6 +213,6 @@ skip = [
 ]
 ignore-words-list = [
     "assertIn",
-    "fpr",
+    "fpr",  # gnupg2 fingerprint regex in apt lib
 ]
 quiet-level = 3  # disable warnings about (1) wrong encoding + (2) binary files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,5 +213,6 @@ skip = [
 ]
 ignore-words-list = [
     "assertIn",
+    "fpr",
 ]
 quiet-level = 3  # disable warnings about (1) wrong encoding + (2) binary files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,6 +199,19 @@ convention = "google"
 max-complexity = 14
 
 [tool.codespell]
-skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.vscode,.coverage,htmlcov"
-ignore-words-list = "assertIn"
-quiet-level = 3
+skip = [
+    ".git",
+    ".tox",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".vscode",
+    "build",
+    "htmlcov",
+    "venv",
+    "icon.svg",
+]
+ignore-words-list = [
+    "assertIn",
+]
+quiet-level = 3  # disable warnings about (1) wrong encoding + (2) binary files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,7 @@ select = [
     # conventional names
     "C",
     # flake8-copyright
-    # FIXME: enable when we switch to --preview for format
-    # "CPY",
+    "CPY",
     # Pycodestyle (error)
     "E",
     # Pyflakes

--- a/tests/integration/test_sysctl.py
+++ b/tests/integration/test_sysctl.py
@@ -29,9 +29,11 @@ def test_multiple_configure():
 
     test_file_2 = Path("/etc/sysctl.d/90-juju-test2")
     merged_file = Path("/etc/sysctl.d/95-juju-sysctl.conf")
-    result = check_output(
-        ["sysctl", "net.ipv4.tcp_max_syn_backlog", "net.ipv4.tcp_window_scaling"]
-    )
+    result = check_output([
+        "sysctl",
+        "net.ipv4.tcp_max_syn_backlog",
+        "net.ipv4.tcp_window_scaling",
+    ])
     assert (
         "net.ipv4.tcp_max_syn_backlog = 4096\nnet.ipv4.tcp_window_scaling = 2\n" in result.decode()
     )

--- a/tests/unit/fake_snapd.py
+++ b/tests/unit/fake_snapd.py
@@ -127,23 +127,21 @@ class Handler(http.server.BaseHTTPRequestHandler):
         return json.loads(body)
 
     def get_sections(self, match, query, data):
-        self.respond(
-            {
-                "type": "sync",
-                "status-code": 200,
-                "status": "OK",
-                "result": {
-                    [
-                        "featured",
-                        "database",
-                        "ops",
-                        "messaging",
-                        "media",
-                        "internet-of-things",
-                    ]
-                },
-            }
-        )
+        self.respond({
+            "type": "sync",
+            "status-code": 200,
+            "status": "OK",
+            "result": {
+                [
+                    "featured",
+                    "database",
+                    "ops",
+                    "messaging",
+                    "media",
+                    "internet-of-things",
+                ]
+            },
+        })
 
 
 def start_server():

--- a/tests/unit/test_dnf.py
+++ b/tests/unit/test_dnf.py
@@ -17,37 +17,27 @@ example_version_output = """
 
   Installed: rpm-0:4.16.1.3-22.el9.x86_64 at Mon 06 Mar 2023 03:55:23 PM GMT
   Built    : builder@centos.org at Mon 19 Dec 2022 11:57:50 PM GMT
-""".strip(
-    "\n"
-)
+""".strip("\n")
 
 example_installed_output = """
 Installed Packages
 NetworkManager.x86_64 1:1.42.2-1.el9 @baseos
-""".strip(
-    "\n"
-)
+""".strip("\n")
 
 example_available_output = """
 Available Packages
 slurm-slurmd.x86_64 22.05.6-3.el9 epel
-""".strip(
-    "\n"
-)
+""".strip("\n")
 
 example_bad_state_output = """
 Obsolete Packages
 yowzah yowzah yowzah
-""".strip(
-    "\n"
-)
+""".strip("\n")
 
 example_bad_version_output = """
 Available Packages
 slurm-slurmd.x86_64 yowzah epel
-""".strip(
-    "\n"
-)
+""".strip("\n")
 
 
 class TestDNF(unittest.TestCase):

--- a/tests/unit/test_grub.py
+++ b/tests/unit/test_grub.py
@@ -155,12 +155,10 @@ class TestUtils(BaseTest):
             grub._save_config(path, {"test": '"1234"'})
 
         mock_open.assert_called_once_with(path, "w", encoding="UTF-8")
-        mock_open.return_value.write.assert_has_calls(
-            [
-                mock.call(grub.CONFIG_HEADER),
-                mock.call("test='\"1234\"'\n"),
-            ]
-        )
+        mock_open.return_value.write.assert_has_calls([
+            mock.call(grub.CONFIG_HEADER),
+            mock.call("test='\"1234\"'\n"),
+        ])
 
     def test_save_config_overwrite(self):
         """Test overwriting if GRUB config already exist."""
@@ -568,15 +566,13 @@ class TestFullConfig(BaseTest):
         self.filecmp.cmp.assert_called_once_with(
             Path("/boot/grub/grub.cfg"), Path("/tmp/tmp_grub.cfg")
         )
-        self.check_call.assert_has_calls(
-            [
-                mock.call(
-                    ["/usr/sbin/grub-mkconfig", "-o", "/tmp/tmp_grub.cfg"],
-                    stderr=subprocess.STDOUT,
-                ),
-                mock.call(["/usr/sbin/update-grub"], stderr=subprocess.STDOUT),
-            ]
-        )
+        self.check_call.assert_has_calls([
+            mock.call(
+                ["/usr/sbin/grub-mkconfig", "-o", "/tmp/tmp_grub.cfg"],
+                stderr=subprocess.STDOUT,
+            ),
+            mock.call(["/usr/sbin/update-grub"], stderr=subprocess.STDOUT),
+        ])
 
     def test_update_validation_error(self):
         """Test update raising ValidationError."""
@@ -614,12 +610,10 @@ class TestFullConfig(BaseTest):
         self.filecmp.cmp.assert_called_once_with(
             Path("/boot/grub/grub.cfg"), Path("/tmp/tmp_grub.cfg")
         )
-        self.check_call.assert_has_calls(
-            [
-                mock.call(
-                    ["/usr/sbin/grub-mkconfig", "-o", "/tmp/tmp_grub.cfg"],
-                    stderr=subprocess.STDOUT,
-                ),
-                mock.call(["/usr/sbin/update-grub"], stderr=subprocess.STDOUT),
-            ]
-        )
+        self.check_call.assert_has_calls([
+            mock.call(
+                ["/usr/sbin/grub-mkconfig", "-o", "/tmp/tmp_grub.cfg"],
+                stderr=subprocess.STDOUT,
+            ),
+            mock.call(["/usr/sbin/update-grub"], stderr=subprocess.STDOUT),
+        ])

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -715,106 +715,98 @@ class TestSocketClient(unittest.TestCase):
             nonlocal change_started
             if method == "PUT" and path == "snaps/test/conf":
                 return io.BytesIO(
-                    json.dumps(
-                        {
-                            "type": "async",
-                            "status-code": 202,
-                            "status": "Accepted",
-                            "result": None,
-                            "change": "97",
-                        }
-                    ).encode("utf-8")
+                    json.dumps({
+                        "type": "async",
+                        "status-code": 202,
+                        "status": "Accepted",
+                        "result": None,
+                        "change": "97",
+                    }).encode("utf-8")
                 )
             if method == "GET" and path == "changes/97" and not change_started:
                 change_started = True
                 return io.BytesIO(
-                    json.dumps(
-                        {
-                            "type": "sync",
-                            "status-code": 200,
-                            "status": "OK",
-                            "result": {
-                                "id": "97",
-                                "kind": "configure-snap",
-                                "summary": 'Change configuration of "test" snap',
-                                "status": "Do",
-                                "tasks": [
-                                    {
-                                        "id": "1028",
-                                        "kind": "run-hook",
-                                        "summary": 'Run configure hook of "test" snap',
-                                        "status": "Do",
-                                        "progress": {"label": "", "done": 0, "total": 1},
-                                        "spawn-time": "2024-11-28T20:02:47.498399651+00:00",
-                                        "data": {"affected-snaps": ["test"]},
-                                    }
-                                ],
-                                "ready": False,
-                                "spawn-time": "2024-11-28T20:02:47.49842583+00:00",
-                            },
-                        }
-                    ).encode("utf-8")
+                    json.dumps({
+                        "type": "sync",
+                        "status-code": 200,
+                        "status": "OK",
+                        "result": {
+                            "id": "97",
+                            "kind": "configure-snap",
+                            "summary": 'Change configuration of "test" snap',
+                            "status": "Do",
+                            "tasks": [
+                                {
+                                    "id": "1028",
+                                    "kind": "run-hook",
+                                    "summary": 'Run configure hook of "test" snap',
+                                    "status": "Do",
+                                    "progress": {"label": "", "done": 0, "total": 1},
+                                    "spawn-time": "2024-11-28T20:02:47.498399651+00:00",
+                                    "data": {"affected-snaps": ["test"]},
+                                }
+                            ],
+                            "ready": False,
+                            "spawn-time": "2024-11-28T20:02:47.49842583+00:00",
+                        },
+                    }).encode("utf-8")
                 )
             if method == "GET" and path == "changes/97" and not change_finished:
                 change_finished = True
                 return io.BytesIO(
-                    json.dumps(
-                        {
-                            "type": "sync",
-                            "status-code": 200,
-                            "status": "OK",
-                            "result": {
-                                "id": "97",
-                                "kind": "configure-snap",
-                                "summary": 'Change configuration of "test" snap',
-                                "status": "Doing",
-                                "tasks": [
-                                    {
-                                        "id": "1029",
-                                        "kind": "run-hook",
-                                        "summary": 'Run configure hook of "test" snap',
-                                        "status": "Doing",
-                                        "progress": {"label": "", "done": 1, "total": 1},
-                                        "spawn-time": "2024-11-28T20:02:47.498399651+00:00",
-                                        "data": {"affected-snaps": ["test"]},
-                                    }
-                                ],
-                                "ready": False,
-                                "spawn-time": "2024-11-28T20:02:47.49842583+00:00",
-                            },
-                        }
-                    ).encode("utf-8")
+                    json.dumps({
+                        "type": "sync",
+                        "status-code": 200,
+                        "status": "OK",
+                        "result": {
+                            "id": "97",
+                            "kind": "configure-snap",
+                            "summary": 'Change configuration of "test" snap',
+                            "status": "Doing",
+                            "tasks": [
+                                {
+                                    "id": "1029",
+                                    "kind": "run-hook",
+                                    "summary": 'Run configure hook of "test" snap',
+                                    "status": "Doing",
+                                    "progress": {"label": "", "done": 1, "total": 1},
+                                    "spawn-time": "2024-11-28T20:02:47.498399651+00:00",
+                                    "data": {"affected-snaps": ["test"]},
+                                }
+                            ],
+                            "ready": False,
+                            "spawn-time": "2024-11-28T20:02:47.49842583+00:00",
+                        },
+                    }).encode("utf-8")
                 )
             if method == "GET" and path == "changes/97" and change_finished:
                 return io.BytesIO(
-                    json.dumps(
-                        {
-                            "type": "sync",
-                            "status-code": 200,
-                            "status": "OK",
-                            "result": {
-                                "id": "98",
-                                "kind": "configure-snap",
-                                "summary": 'Change configuration of "test" snap',
-                                "status": "Done",
-                                "tasks": [
-                                    {
-                                        "id": "1030",
-                                        "kind": "run-hook",
-                                        "summary": 'Run configure hook of "test" snap',
-                                        "status": "Done",
-                                        "progress": {"label": "", "done": 1, "total": 1},
-                                        "spawn-time": "2024-11-28T20:06:41.415929854+00:00",
-                                        "ready-time": "2024-11-28T20:06:41.797437537+00:00",
-                                        "data": {"affected-snaps": ["test"]},
-                                    }
-                                ],
-                                "ready": True,
-                                "spawn-time": "2024-11-28T20:06:41.415955681+00:00",
-                                "ready-time": "2024-11-28T20:06:41.797440022+00:00",
-                            },
-                        }
-                    ).encode("utf-8")
+                    json.dumps({
+                        "type": "sync",
+                        "status-code": 200,
+                        "status": "OK",
+                        "result": {
+                            "id": "98",
+                            "kind": "configure-snap",
+                            "summary": 'Change configuration of "test" snap',
+                            "status": "Done",
+                            "tasks": [
+                                {
+                                    "id": "1030",
+                                    "kind": "run-hook",
+                                    "summary": 'Run configure hook of "test" snap',
+                                    "status": "Done",
+                                    "progress": {"label": "", "done": 1, "total": 1},
+                                    "spawn-time": "2024-11-28T20:06:41.415929854+00:00",
+                                    "ready-time": "2024-11-28T20:06:41.797437537+00:00",
+                                    "data": {"affected-snaps": ["test"]},
+                                }
+                            ],
+                            "ready": True,
+                            "spawn-time": "2024-11-28T20:06:41.415955681+00:00",
+                            "ready-time": "2024-11-28T20:06:41.797440022+00:00",
+                        },
+                    }).encode("utf-8")
                 )
             raise RuntimeError("unknown request")
 
@@ -832,33 +824,29 @@ class TestSocketClient(unittest.TestCase):
         ) -> typing.IO[bytes]:
             if method == "PUT" and path == "snaps/test/conf":
                 return io.BytesIO(
-                    json.dumps(
-                        {
-                            "type": "async",
-                            "status-code": 202,
-                            "status": "Accepted",
-                            "result": None,
-                            "change": "97",
-                        }
-                    ).encode("utf-8")
+                    json.dumps({
+                        "type": "async",
+                        "status-code": 202,
+                        "status": "Accepted",
+                        "result": None,
+                        "change": "97",
+                    }).encode("utf-8")
                 )
             if method == "GET" and path == "changes/97":
                 return io.BytesIO(
-                    json.dumps(
-                        {
-                            "type": "sync",
-                            "status-code": 200,
-                            "status": "OK",
-                            "result": {
-                                "id": "97",
-                                "kind": "configure-snap",
-                                "summary": 'Change configuration of "test" snap',
-                                "status": "Error",
-                                "ready": False,
-                                "spawn-time": "2024-11-28T20:02:47.49842583+00:00",
-                            },
-                        }
-                    ).encode("utf-8")
+                    json.dumps({
+                        "type": "sync",
+                        "status-code": 200,
+                        "status": "OK",
+                        "result": {
+                            "id": "97",
+                            "kind": "configure-snap",
+                            "summary": 'Change configuration of "test" snap',
+                            "status": "Error",
+                            "ready": False,
+                            "spawn-time": "2024-11-28T20:02:47.49842583+00:00",
+                        },
+                    }).encode("utf-8")
                 )
             raise RuntimeError("unknown request")
 

--- a/tests/unit/test_systemd.py
+++ b/tests/unit/test_systemd.py
@@ -159,12 +159,10 @@ class TestSystemD(unittest.TestCase):
         # We can't reload, so we restart
         mockp, kw = make_mock([1, 0], check=True)
         systemd.service_reload("mysql", restart_on_failure=True)
-        mockp.assert_has_calls(
-            [
-                call(["systemctl", "reload", "mysql"], **kw),
-                call(["systemctl", "restart", "mysql"], **kw),
-            ]
-        )
+        mockp.assert_has_calls([
+            call(["systemctl", "reload", "mysql"], **kw),
+            call(["systemctl", "restart", "mysql"], **kw),
+        ])
 
         # We should only restart if requested.
         mockp, kw = make_mock([1, 0], check=True)
@@ -176,12 +174,10 @@ class TestSystemD(unittest.TestCase):
         self.assertRaises(
             systemd.SystemdError, systemd.service_reload, "mysql", restart_on_failure=True
         )
-        mockp.assert_has_calls(
-            [
-                call(["systemctl", "reload", "mysql"], **kw),
-                call(["systemctl", "restart", "mysql"], **kw),
-            ]
-        )
+        mockp.assert_has_calls([
+            call(["systemctl", "reload", "mysql"], **kw),
+            call(["systemctl", "restart", "mysql"], **kw),
+        ])
 
     @with_mock_subp
     def test_service_pause(self, make_mock):
@@ -189,59 +185,49 @@ class TestSystemD(unittest.TestCase):
         mockp, kw = make_mock([0, 0, 3])
 
         systemd.service_pause("mysql")
-        mockp.assert_has_calls(
-            [
-                call(["systemctl", "disable", "--now", "mysql"], **kw),
-                call(["systemctl", "mask", "mysql"], **kw),
-                call(["systemctl", "--quiet", "is-active", "mysql"], **kw),
-            ]
-        )
+        mockp.assert_has_calls([
+            call(["systemctl", "disable", "--now", "mysql"], **kw),
+            call(["systemctl", "mask", "mysql"], **kw),
+            call(["systemctl", "--quiet", "is-active", "mysql"], **kw),
+        ])
 
         # Could not stop service!
         mockp, kw = make_mock([0, 0, 0])
         self.assertRaises(systemd.SystemdError, systemd.service_pause, "mysql")
-        mockp.assert_has_calls(
-            [
-                call(["systemctl", "disable", "--now", "mysql"], **kw),
-                call(["systemctl", "mask", "mysql"], **kw),
-                call(["systemctl", "--quiet", "is-active", "mysql"], **kw),
-            ]
-        )
+        mockp.assert_has_calls([
+            call(["systemctl", "disable", "--now", "mysql"], **kw),
+            call(["systemctl", "mask", "mysql"], **kw),
+            call(["systemctl", "--quiet", "is-active", "mysql"], **kw),
+        ])
 
     @with_mock_subp
     def test_service_resume(self, make_mock):
         # Service is already running
         mockp, kw = make_mock([0, 0, 0])
         systemd.service_resume("mysql")
-        mockp.assert_has_calls(
-            [
-                call(["systemctl", "unmask", "mysql"], **kw),
-                call(["systemctl", "enable", "--now", "mysql"], **kw),
-                call(["systemctl", "--quiet", "is-active", "mysql"], **kw),
-            ]
-        )
+        mockp.assert_has_calls([
+            call(["systemctl", "unmask", "mysql"], **kw),
+            call(["systemctl", "enable", "--now", "mysql"], **kw),
+            call(["systemctl", "--quiet", "is-active", "mysql"], **kw),
+        ])
 
         # Service was stopped
         mockp, kw = make_mock([0, 0, 0])
         systemd.service_resume("mysql")
-        mockp.assert_has_calls(
-            [
-                call(["systemctl", "unmask", "mysql"], **kw),
-                call(["systemctl", "enable", "--now", "mysql"], **kw),
-                call(["systemctl", "--quiet", "is-active", "mysql"], **kw),
-            ]
-        )
+        mockp.assert_has_calls([
+            call(["systemctl", "unmask", "mysql"], **kw),
+            call(["systemctl", "enable", "--now", "mysql"], **kw),
+            call(["systemctl", "--quiet", "is-active", "mysql"], **kw),
+        ])
 
         # Could not start service!
         mockp, kw = make_mock([0, 0, 3])
         self.assertRaises(systemd.SystemdError, systemd.service_resume, "mysql")
-        mockp.assert_has_calls(
-            [
-                call(["systemctl", "unmask", "mysql"], **kw),
-                call(["systemctl", "enable", "--now", "mysql"], **kw),
-                call(["systemctl", "--quiet", "is-active", "mysql"], **kw),
-            ]
-        )
+        mockp.assert_has_calls([
+            call(["systemctl", "unmask", "mysql"], **kw),
+            call(["systemctl", "enable", "--now", "mysql"], **kw),
+            call(["systemctl", "--quiet", "is-active", "mysql"], **kw),
+        ])
 
     @with_mock_subp
     def test_daemon_reload(self, make_mock):

--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,7 @@ deps =
 allowlist_externals =
     mkdir
 commands_pre =
-    mkdir --parents .report
+    mkdir --parents .report  # --parents allows the folder to already exist
 commands =
     coverage run --source={[vars]lib_dir} \
                  -m pytest \

--- a/tox.ini
+++ b/tox.ini
@@ -29,22 +29,20 @@ passenv =
 [testenv:fmt]
 description = Apply coding style standards to code
 deps =
-    black
-    ruff
+    ruff==0.7.0
 commands =
-    ruff check --fix {[vars]all_dir}
-    black {[vars]all_dir}
+    ruff check --fix
+    ruff format
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
-    black
-    ruff
-    codespell
+    codespell==2.3.0
+    ruff==0.7.0
 commands =
-    codespell {toxinidir}
-    ruff check {[vars]all_dir}
-    black --check --diff {[vars]all_dir}
+    codespell
+    ruff check --preview  # --preview means include 'unstable' rules/fixes
+    ruff format --check  # FIXME: add --preview; disabled for now to make diff less noisy
 
 [testenv:unit]
 description = Run unit tests

--- a/tox.ini
+++ b/tox.ini
@@ -54,6 +54,10 @@ deps =
     -r{toxinidir}/requirements.txt
     pyfakefs==5.5.0
     dbus-fast==1.90.2
+allowlist_externals =
+    mkdir
+commands_pre =
+    mkdir --parents .report
 commands =
     coverage run --source={[vars]lib_dir} \
                  -m pytest \
@@ -61,11 +65,13 @@ commands =
                  --tb native \
                  -v \
                  {posargs}
+    coverage xml -o .report/coverage.xml
+    coverage html --show-contexts
     coverage report
 
 [testenv:integration]
 description = Build a LXD container for integration tests then run the tests
-allowlist_externals = 
+allowlist_externals =
     lxc
     bash
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -31,8 +31,8 @@ description = Apply coding style standards to code
 deps =
     ruff==0.7.0
 commands =
-    ruff check --fix
-    ruff format
+    ruff check --preview --fix
+    ruff format --preview
 
 [testenv:lint]
 description = Check code against coding style standards
@@ -42,7 +42,7 @@ deps =
 commands =
     codespell
     ruff check --preview  # --preview means include 'unstable' rules/fixes
-    ruff format --check  # FIXME: add --preview; disabled for now to make diff less noisy
+    ruff format --preview --check
 
 [testenv:unit]
 description = Run unit tests

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ deps =
     codespell==2.3.0
     ruff==0.7.0
 commands =
-    codespell
+    codespell {toxinidir}/ --toml={toxinidir}/pyproject.toml
     ruff check --preview  # --preview means include 'unstable' rules/fixes
     ruff format --preview --check
 


### PR DESCRIPTION
This PR updates `tox.ini` to use `ruff --preview` for all linting and formatting (dropping `black`), and have `codespell` run correctly, updating `pyproject.toml` accordingly.

The core of the PR is the changes to `tox.ini` and `pyproject.toml`. The linting rules for `ruff` have been updated to include all the rules that `ops` uses. To allow linting to continue to pass, any rules that are currently broken in a single file are ignored for that file, while rules that are broken in multiple files are ignored globally. These ignores are marked with a `FIXME` to distinguish them from intentional ignores that are copied from `ops`.

Changes to other files are either from `ruff format` or from `codespell`. There are typo corrections and a couple of small formatting changes to libraries, which are not significant enough to warrant bumping `LIB_PATCH` and triggering a release. There are also some bigger formatting changes for large dictionaries in tests.

Subsequent PRs will fix the ignored linting issues in individual libraries.