### PR TITLE
ci: remove linting ignores for snap.py

### DIFF
--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -122,7 +122,7 @@ def _cache_init(func: Callable[_P, _T]) -> Callable[_P, _T]:
 # because setting snap config values to null removes the key so a null value can't be returned
 _JSONLeaf: TypeAlias = 'str | int | float | bool'
 JSONType: TypeAlias = "dict[str, JSONType] | list[JSONType] | _JSONLeaf"
-# we also need a jsonable type for arguments
+# we also need a jsonable type for arguments,
 # which (a) uses abstract types and (b) may contain None
 JSONAble: TypeAlias = "Mapping[str, JSONAble] | Sequence[JSONAble] | _JSONLeaf | None"
 
@@ -803,14 +803,14 @@ class SnapClient:
         Args:
             socket_path: a path to the socket on the filesystem. Defaults to /run/snap/snapd.socket
             opener: specifies an opener for unix socket, if unspecified a default is used
-            base_url: base url for making requests to the snap client. Must be an http(s) url.
+            base_url: base URL for making requests to the snap client. Must be an HTTP(S) URL.
                 Defaults to http://localhost/v2/
             timeout: timeout in seconds to use when making requests to the API. Default is 30.0s.
         """
         if opener is None:
             opener = self._get_default_opener(socket_path)
         self.opener = opener
-        # address ruff's suspicious-url-open-usage (S310)
+        # Address ruff's suspicious-url-open-usage (S310)
         if not base_url.startswith(("http:", "https:")):
             raise ValueError("base_url must start with 'http:' or 'https:'")
         self.base_url = base_url

--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -674,7 +674,7 @@ class Snap:
         try:
             self._apps = self._snap_client.get_installed_snap_apps(self._name)
         except SnapAPIError:
-            logger.debug(f"Unable to retrieve snap apps for {self._name}")
+            logger.debug("Unable to retrieve snap apps for %s", self._name)
             self._apps = []
 
     @property
@@ -1220,10 +1220,10 @@ def _wrap_snap_operations(
                 )
             snaps.append(snap)
         except SnapError as e:  # noqa: PERF203
-            logger.warning(f"Failed to {op} snap {s}: {e.message}!")
+            logger.warning("Failed to %s snap %s: %s!", op, s, e.message)
             errors.append(s)
         except SnapNotFoundError:
-            logger.warning(f"Snap '{s}' not found in cache!")
+            logger.warning("Snap '%s' not found in cache!", s)
             errors.append(s)
 
     if errors:
@@ -1270,7 +1270,11 @@ def install_local(
         try:
             return c[snap_name]
         except SnapAPIError as e:
-            logger.error(f"Could not find snap {snap_name} when querying Snapd socket: {e.body}")
+            logger.error(
+                "Could not find snap %s when querying Snapd socket: %s",
+                snap_name,
+                e.body,
+            )
             raise SnapError(f"Failed to find snap {snap_name} in Snap cache") from e
     except CalledProcessError as e:
         raise SnapError(f"Could not install snap {filename}: {e.output}") from e

--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -906,7 +906,7 @@ class SnapClient:
             body: dict[str, JSONType]
             try:
                 body = json.loads(e.read().decode())["result"]  # json.loads -> Any
-            except (IOError, ValueError, KeyError) as e2:
+            except (OSError, ValueError, KeyError) as e2:
                 # Will only happen on read error or if Pebble sends invalid JSON.
                 body = {}
                 message = "{} - {}".format(type(e2).__name__, e2)

--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -810,13 +810,16 @@ class SnapClient:
         Args:
             socket_path: a path to the socket on the filesystem. Defaults to /run/snap/snapd.socket
             opener: specifies an opener for unix socket, if unspecified a default is used
-            base_url: base url for making requests to the snap client. Defaults to
-                http://localhost/v2/
+            base_url: base url for making requests to the snap client. Must be an http(s) url.
+                Defaults to http://localhost/v2/
             timeout: timeout in seconds to use when making requests to the API. Default is 30.0s.
         """
         if opener is None:
             opener = self._get_default_opener(socket_path)
         self.opener = opener
+        # address ruff's suspicious-url-open-usage (S310)
+        if not base_url.startswith(("http:", "https:")):
+            raise ValueError("base_url must start with 'http:' or 'https:'")
         self.base_url = base_url
         self.timeout = timeout
 
@@ -895,7 +898,7 @@ class SnapClient:
 
         if headers is None:
             headers = {}
-        request = urllib.request.Request(url, method=method, data=data, headers=headers)
+        request = urllib.request.Request(url, method=method, data=data, headers=headers)  # noqa: S310
 
         try:
             response = self.opener.open(request, timeout=self.timeout)

--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -987,7 +987,7 @@ class SnapCache(Mapping[str, Snap]):
             # currently exist.
             return
 
-        with open("/var/cache/snapd/names", "r") as f:
+        with open("/var/cache/snapd/names") as f:
             for line in f:
                 if line.strip():
                     self._snap_map[line.strip()] = None

--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -122,7 +122,8 @@ def _cache_init(func: Callable[_P, _T]) -> Callable[_P, _T]:
 # because setting snap config values to null removes the key so a null value can't be returned
 _JSONLeaf: TypeAlias = 'str | int | float | bool'
 JSONType: TypeAlias = "dict[str, JSONType] | list[JSONType] | _JSONLeaf"
-# we also need a jsonable type for arguments, which (a) uses abstract types and (b) may contain None
+# we also need a jsonable type for arguments
+# which (a) uses abstract types and (b) may contain None
 JSONAble: TypeAlias = "Mapping[str, JSONAble] | Sequence[JSONAble] | _JSONLeaf | None"
 
 
@@ -319,7 +320,11 @@ class Snap:
 
     def __str__(self) -> str:
         """Represent the snap object as a string."""
-        return f"<{type(self).__name__}: {self._name}-{self._revision}.{self._channel} -- {self._state}>"
+        return (
+            f"<{type(self).__name__}: "
+            f"{self._name}-{self._revision}.{self._channel}"
+            f" -- {self._state}>"
+        )
 
     def _snap(self, command: str, optargs: Iterable[str] | None = None) -> str:
         """Perform a snap operation.

--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -343,7 +343,7 @@ class Snap(object):
         optargs = optargs or []
         args = ["snap", command, self._name, *optargs]
         try:
-            return subprocess.check_output(args, universal_newlines=True)
+            return subprocess.check_output(args, text=True)
         except CalledProcessError as e:
             raise SnapError(
                 "Snap: {!r}; command {!r} failed with output = {!r}".format(
@@ -374,7 +374,7 @@ class Snap(object):
         args = ["snap", *command, *services]
 
         try:
-            return subprocess.run(args, universal_newlines=True, check=True, capture_output=True)
+            return subprocess.run(args, text=True, check=True, capture_output=True)
         except CalledProcessError as e:
             raise SnapError("Could not {} for snap [{}]: {}".format(args, self._name, e.stderr))
 
@@ -480,7 +480,7 @@ class Snap(object):
 
         args = ["snap", *command]
         try:
-            subprocess.run(args, universal_newlines=True, check=True, capture_output=True)
+            subprocess.run(args, text=True, check=True, capture_output=True)
         except CalledProcessError as e:
             raise SnapError("Could not {} for snap [{}]: {}".format(args, self._name, e.stderr))
 
@@ -511,7 +511,7 @@ class Snap(object):
             alias = application
         args = ["snap", "alias", f"{self.name}.{application}", alias]
         try:
-            subprocess.check_output(args, universal_newlines=True)
+            subprocess.check_output(args, text=True)
         except CalledProcessError as e:
             raise SnapError(
                 "Snap: {!r}; command {!r} failed with output = {!r}".format(
@@ -1265,7 +1265,7 @@ def install_local(
     if dangerous:
         args.append("--dangerous")
     try:
-        result = subprocess.check_output(args, universal_newlines=True).splitlines()[-1]
+        result = subprocess.check_output(args, text=True).splitlines()[-1]
         snap_name, _ = result.split(" ", 1)
         snap_name = ansi_filter.sub("", snap_name)
 
@@ -1291,7 +1291,7 @@ def _system_set(config_item: str, value: str) -> None:
     """
     args = ["snap", "set", "system", "{}={}".format(config_item, value)]
     try:
-        subprocess.check_call(args, universal_newlines=True)
+        subprocess.check_call(args, text=True)
     except CalledProcessError:
         raise SnapError("Failed setting system config '{}' to '{}'".format(config_item, value))
 

--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -1219,7 +1219,7 @@ def _wrap_snap_operations(
                     revision=revision,
                 )
             snaps.append(snap)
-        except SnapError as e:
+        except SnapError as e:  # noqa: PERF203
             logger.warning(f"Failed to {op} snap {s}: {e.message}!")
             errors.append(s)
         except SnapNotFoundError:

--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -219,7 +219,7 @@ class MetaCache(type):
         return cls._cache[name]
 
 
-class _Cache(object, metaclass=MetaCache):
+class _Cache(metaclass=MetaCache):
     _cache = None
 
 
@@ -274,7 +274,7 @@ class SnapNotFoundError(Error):
     """Raised when a requested snap is not known to the system."""
 
 
-class Snap(object):
+class Snap:
     """Represents a snap package and its properties.
 
     `Snap` exposes the following properties about a snap:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,9 +154,6 @@ keep-runtime-typing = true
     # use text instead of universal_newlines with subprocess.run
     # FIXME
     "UP021",
-    # catch OSError instead of alias IOError
-    # FIXME
-    "UP024",
 ]
 "tests/*" = [
     # All documentation linting.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,9 +85,6 @@ ignore = [
     # Unused noqa
     # FIXME
     "RUF100",
-    # use unpacking instead of concatenation with lists
-    # FIXME
-    "RUF005",
     # subprocess: check for execution of untrusted input
     # FIXME: individually validate or noqa these
     "S603",
@@ -153,6 +150,9 @@ keep-runtime-typing = true
     "UP032",
 ]
 "lib/charms/operator_libs_linux/v0/sysctl.py" = [
+    # use unpacking instead of concatenation with lists
+    # FIXME
+    "RUF005",
     # Unnecessary open mode parameters
     # FIXME
     "UP015",
@@ -225,6 +225,9 @@ keep-runtime-typing = true
     "UP015",
 ]
 "tests/unit/test_snap.py" = [
+    # use unpacking instead of concatenation with lists
+    # FIXME
+    "RUF005",
     # implicit Optional in typing
     # FIXME: typing
     "RUF013",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,12 +82,6 @@ ignore = [
     "SIM117",
 ]
 
-[tool.ruff.lint.pyupgrade]
-# Preserve types, even if a file imports `from __future__ import annotations`.
-# Since we target py 3.8, we want to keep using List[str] and Optional[str]
-# FIXME: do we need this?
-keep-runtime-typing = true
-
 [tool.ruff.lint.per-file-ignores]
 "lib/charms/operator_libs_linux/v0/apt.py" = [
     # Use from err or from None explicitly

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,9 +79,6 @@ ignore = [
     # try/except inside loop
     # FIXME: lift or noqa individually as appropriate
     "PERF203",
-    # Unused noqa
-    # FIXME
-    "RUF100",
     # subprocess: check for execution of untrusted input
     # FIXME: individually validate or noqa these
     "S603",
@@ -104,6 +101,9 @@ keep-runtime-typing = true
     # Line too long
     # FIXME
     "E501",
+    # Unused noqa
+    # FIXME: remove unneeded noqas
+    "RUF100",
     # Use a context manager for opening files
     # FIXME: false positive, noqa it
     "SIM115",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,9 +94,6 @@ ignore = [
     # subprocess: starting process with a partial executable path
     # FIXME: individually validate or noqa these
     "S607",
-    # Unnecessary open mode parameters
-    # FIXME
-    "UP015",
 ]
 
 [tool.ruff.lint.pyupgrade]
@@ -113,6 +110,9 @@ keep-runtime-typing = true
     # Use a context manager for opening files
     # FIXME: false positive, noqa it
     "SIM115",
+    # Unnecessary open mode parameters
+    # FIXME
+    "UP015",
     # prefer capture_output over using stdout+stderr with PIPE
     # FIXME
     "UP022",
@@ -129,6 +129,9 @@ keep-runtime-typing = true
     # Probably insecure usage of temporary file or directory under /tmp
     # FIXME: use stdlib tempfile
     "S108",
+    # Unnecessary open mode parameters
+    # FIXME
+    "UP015",
 ]
 "lib/charms/operator_libs_linux/v0/juju_systemd_notices.py" = [
     # Line too long
@@ -149,6 +152,11 @@ keep-runtime-typing = true
     # FIXME: migrate to fstrings
     "UP032",
 ]
+"lib/charms/operator_libs_linux/v0/sysctl.py" = [
+    # Unnecessary open mode parameters
+    # FIXME
+    "UP015",
+]
 "tests/*" = [
     # All documentation linting.
     "D",
@@ -164,6 +172,11 @@ keep-runtime-typing = true
     "S106",
     # Probably insecure usage of temporary file or directory (e.g. /tmp/bad.list)
     "S108",
+]
+"tests/integration/helpers.py" = [
+    # Unnecessary open mode parameters
+    # FIXME
+    "UP015",
 ]
 "tests/integration/test_apt.py" = [
     # Use fstrings instead of `format`
@@ -182,6 +195,11 @@ keep-runtime-typing = true
     # Use fstrings instead of `format`
     # FIXME: migrate to fstrings
     "UP032",
+]
+"tests/integration/test_sysctl.py" = [
+    # Unnecessary open mode parameters
+    # FIXME
+    "UP015",
 ]
 "tests/integration/test_grub.py" = [
     # detected, some yoda conditionals were
@@ -202,6 +220,9 @@ keep-runtime-typing = true
     # combine if branches using logical or
     # FIXME
     "SIM114",
+    # Unnecessary open mode parameters
+    # FIXME
+    "UP015",
 ]
 "tests/unit/test_snap.py" = [
     # implicit Optional in typing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,9 +73,6 @@ ignore = [
     # Use a single `with` statement with multiple contexts instead of nested `with` statements
     "SIM117",
 
-    # too many leading # before block comment
-    # FIXME
-    "E266",
     # try/except inside loop
     # FIXME: lift or noqa individually as appropriate
     "PERF203",
@@ -190,6 +187,9 @@ keep-runtime-typing = true
     "UP015",
 ]
 "tests/integration/test_apt.py" = [
+    # too many leading # before block comment
+    # FIXME
+    "E266",
     # Use fstrings instead of `format`
     # FIXME: migrate to fstrings
     "UP032",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,9 +73,6 @@ ignore = [
     # Use a single `with` statement with multiple contexts instead of nested `with` statements
     "SIM117",
 
-    # Use from err or from None explicitly
-    # FIXME
-    "B904",
     # too many leading # before block comment
     # FIXME
     "E266",
@@ -101,6 +98,9 @@ keep-runtime-typing = true
 
 [tool.ruff.lint.per-file-ignores]
 "lib/charms/operator_libs_linux/v0/apt.py" = [
+    # Use from err or from None explicitly
+    # FIXME
+    "B904",
     # Line too long
     # FIXME
     "E501",
@@ -118,6 +118,9 @@ keep-runtime-typing = true
     "UP032",
 ]
 "lib/charms/operator_libs_linux/v0/dnf.py" = [
+    # Use from err or from None explicitly
+    # FIXME
+    "B904",
     # prefer capture_output over using stdout+stderr with PIPE
     # FIXME
     "UP022",
@@ -150,12 +153,20 @@ keep-runtime-typing = true
     "UP032",
 ]
 "lib/charms/operator_libs_linux/v0/sysctl.py" = [
+    # Use from err or from None explicitly
+    # FIXME
+    "B904",
     # use unpacking instead of concatenation with lists
     # FIXME
     "RUF005",
     # Unnecessary open mode parameters
     # FIXME
     "UP015",
+]
+"lib/charms/operator_libs_linux/v1/systemd.py" = [
+    # Use from err or from None explicitly
+    # FIXME
+    "B904",
 ]
 "tests/*" = [
     # All documentation linting.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,19 +66,20 @@ ignore = [
     "S101",
     # `subprocess` module is possibly insecure
     "S404",
+    # subprocess-without-shell-equals-true
+    # S602 complains if shell is True, which is considered worse due to potential shell exploits
+    # difficult to avoid without noqa, which then becomes meaningless boilerplate every time
+    "S603",
+    # start-process-with-partial-path
+    # wants an absolute path to the executable as the first argument
+    # seems impractical, so also results in noqa boilerplate
+    "S607",
     # Return condition directly, prefer readability.
     "SIM103",
     # Use contextlib.suppress() instead of try/except: pass
     "SIM105",
     # Use a single `with` statement with multiple contexts instead of nested `with` statements
     "SIM117",
-
-    # subprocess: check for execution of untrusted input
-    # FIXME: individually validate or noqa these
-    "S603",
-    # subprocess: starting process with a partial executable path
-    # FIXME: individually validate or noqa these
-    "S607",
 ]
 
 [tool.ruff.lint.pyupgrade]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,9 +97,6 @@ ignore = [
     # Unnecessary open mode parameters
     # FIXME
     "UP015",
-    # prefer capture_output over using stdout+stderr with PIPE
-    # FIXME
-    "UP022",
 ]
 
 [tool.ruff.lint.pyupgrade]
@@ -116,9 +113,17 @@ keep-runtime-typing = true
     # Use a context manager for opening files
     # FIXME: false positive, noqa it
     "SIM115",
+    # prefer capture_output over using stdout+stderr with PIPE
+    # FIXME
+    "UP022",
     # Use fstrings instead of `format`
     # FIXME: migrate to fstrings
     "UP032",
+]
+"lib/charms/operator_libs_linux/v0/dnf.py" = [
+    # prefer capture_output over using stdout+stderr with PIPE
+    # FIXME
+    "UP022",
 ]
 "lib/charms/operator_libs_linux/v0/grub.py" = [
     # Probably insecure usage of temporary file or directory under /tmp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,17 +106,12 @@ ignore = [
     # prefer capture_output over using stdout+stderr with PIPE
     # FIXME
     "UP022",
-    # use {} {} instead if {0} {1} if they're in order
-    # FIXME: migrate to fstrings
-    "UP030",
-    # Use fstrings instead of `format`
-    # FIXME: migrate to fstrings
-    "UP032",
 ]
 
 [tool.ruff.lint.pyupgrade]
 # Preserve types, even if a file imports `from __future__ import annotations`.
 # Since we target py 3.8, we want to keep using List[str] and Optional[str]
+# FIXME: do we need this?
 keep-runtime-typing = true
 
 [tool.ruff.lint.per-file-ignores]
@@ -124,6 +119,9 @@ keep-runtime-typing = true
     # Use a context manager for opening files
     # FIXME: false positive, noqa it
     "SIM115",
+    # Use fstrings instead of `format`
+    # FIXME: migrate to fstrings
+    "UP032",
 ]
 "lib/charms/operator_libs_linux/v0/grub.py" = [
     # Probably insecure usage of temporary file or directory under /tmp
@@ -137,6 +135,11 @@ keep-runtime-typing = true
     # Store a reference to the return value of `asyncio.create_task`
     # FIXME: investigate
     "RUF006",
+]
+"lib/charms/operator_libs_linux/v0/passwd.py" = [
+    # Use fstrings instead of `format`
+    # FIXME: migrate to fstrings
+    "UP032",
 ]
 "tests/*" = [
     # All documentation linting.
@@ -154,15 +157,33 @@ keep-runtime-typing = true
     # Probably insecure usage of temporary file or directory (e.g. /tmp/bad.list)
     "S108",
 ]
+"tests/integration/test_apt.py" = [
+    # Use fstrings instead of `format`
+    # FIXME: migrate to fstrings
+    "UP032",
+]
 "tests/integration/test_passwd.py" = [
     # function call with 'truthy' `shell` parameter
     # FIXME
     "S604",
+    # Use fstrings instead of `format`
+    # FIXME: migrate to fstrings
+    "UP032",
+]
+"tests/integration/test_snap.py" = [
+    # Use fstrings instead of `format`
+    # FIXME: migrate to fstrings
+    "UP032",
 ]
 "tests/integration/test_grub.py" = [
     # detected, some yoda conditionals were
     # FIXME
     "SIM300",
+]
+"tests/unit/fake_snapd.py" = [
+    # Use fstrings instead of `format`
+    # FIXME: migrate to fstrings
+    "UP032",
 ]
 "tests/unit/test_repo.py" = [
     # use context manager for opening files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,9 +151,6 @@ keep-runtime-typing = true
     # inheriting from object
     # FIXME
     "UP004",
-    # use text instead of universal_newlines with subprocess.run
-    # FIXME
-    "UP021",
 ]
 "tests/*" = [
     # All documentation linting.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,9 +91,6 @@ ignore = [
     # use unpacking instead of concatenation with lists
     # FIXME
     "RUF005",
-    # implicit Optional in typing
-    # FIXME: typing
-    "RUF013",
     # subprocess: check for execution of untrusted input
     # FIXME: individually validate or noqa these
     "S603",
@@ -137,6 +134,9 @@ keep-runtime-typing = true
     "RUF006",
 ]
 "lib/charms/operator_libs_linux/v0/passwd.py" = [
+    # implicit Optional in typing
+    # FIXME: typing
+    "RUF013",
     # Use fstrings instead of `format`
     # FIXME: migrate to fstrings
     "UP032",
@@ -194,6 +194,11 @@ keep-runtime-typing = true
     # combine if branches using logical or
     # FIXME
     "SIM114",
+]
+"tests/unit/test_snap.py" = [
+    # implicit Optional in typing
+    # FIXME: typing
+    "RUF013",
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ select = [
     "E",
     # Pyflakes
     "F",
+    # flake8-logging-format
+    "G",
     # isort
     "I001",
     # pep8-naming
@@ -159,6 +161,9 @@ ignore = [
     # Use from err or from None explicitly
     # FIXME
     "B904",
+    # don't use f-strings in logging
+    # FIXME: use %s for deferred evaluation
+    "G004",
 ]
 "tests/*" = [
     # All documentation linting.
@@ -198,6 +203,9 @@ ignore = [
     "UP032",
 ]
 "tests/integration/test_snap.py" = [
+    # don't use str.format in logging
+    # FIXME: use %s for deferred evaluation
+    "G001",
     # Use fstrings instead of `format`
     # FIXME: migrate to fstrings
     "UP032",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,9 +148,6 @@ keep-runtime-typing = true
     # using None explicitly with get
     # FIXME
     "SIM910",
-    # inheriting from object
-    # FIXME
-    "UP004",
 ]
 "tests/*" = [
     # All documentation linting.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,9 +73,6 @@ ignore = [
     # Use a single `with` statement with multiple contexts instead of nested `with` statements
     "SIM117",
 
-    # try/except inside loop
-    # FIXME: lift or noqa individually as appropriate
-    "PERF203",
     # subprocess: check for execution of untrusted input
     # FIXME: individually validate or noqa these
     "S603",
@@ -98,6 +95,9 @@ keep-runtime-typing = true
     # Line too long
     # FIXME
     "E501",
+    # try/except inside loop
+    # FIXME: lift or noqa individually as appropriate
+    "PERF203",
     # Unused noqa
     # FIXME: remove unneeded noqas
     "RUF100",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,9 +79,6 @@ ignore = [
     # too many leading # before block comment
     # FIXME
     "E266",
-    # Line too long
-    # FIXME
-    "E501",
     # try/except inside loop
     # FIXME: lift or noqa individually as appropriate
     "PERF203",
@@ -113,6 +110,9 @@ keep-runtime-typing = true
 
 [tool.ruff.lint.per-file-ignores]
 "lib/charms/operator_libs_linux/v0/apt.py" = [
+    # Line too long
+    # FIXME
+    "E501",
     # Use a context manager for opening files
     # FIXME: false positive, noqa it
     "SIM115",
@@ -126,6 +126,9 @@ keep-runtime-typing = true
     "S108",
 ]
 "lib/charms/operator_libs_linux/v0/juju_systemd_notices.py" = [
+    # Line too long
+    # FIXME
+    "E501",
     # unqualified noqa
     # FIXME
     "RUF100",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,17 +138,6 @@ keep-runtime-typing = true
     # FIXME: investigate
     "RUF006",
 ]
-"lib/charms/operator_libs_linux/v2/snap.py" = [
-    # mutable default argument
-    # FIXME
-    "B006",
-    # audit url open for permitted schemes
-    # FIXME: probably noqa manually
-    "S310",
-    # using None explicitly with get
-    # FIXME
-    "SIM910",
-]
 "tests/*" = [
     # All documentation linting.
     "D",

--- a/tests/integration/juju_systemd_notices/notices-charm/src/charm.py
+++ b/tests/integration/juju_systemd_notices/notices-charm/src/charm.py
@@ -46,7 +46,7 @@ class NoticesCharm(CharmBase):
         systemd.daemon_reload()
         self._systemd_notices.subscribe()
 
-    def _on_start(self, _: StartEvent) -> None:  # noqa
+    def _on_start(self, _: StartEvent) -> None:
         """Handle start event."""
         systemd.service_start("test")
 
@@ -58,7 +58,7 @@ class NoticesCharm(CharmBase):
         """Handle service stopped event."""
         self.unit.status = BlockedStatus("test service not running :(")
 
-    def _on_stop_service_action(self, _) -> None:  # noqa
+    def _on_stop_service_action(self, _) -> None:
         """Handle stop-service action."""
         systemd.service_stop("test")
 

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -326,7 +326,7 @@ class TestSnapCache(unittest.TestCase):
         mock_subprocess.assert_not_called()
 
         foo.ensure(snap.SnapState.Absent)
-        mock_subprocess.assert_called_with(["snap", "remove", "foo"], universal_newlines=True)
+        mock_subprocess.assert_called_with(["snap", "remove", "foo"], text=True)
 
         foo.ensure(snap.SnapState.Latest, classic=True, channel="latest/edge")
 
@@ -338,16 +338,16 @@ class TestSnapCache(unittest.TestCase):
                 "--classic",
                 '--channel="latest/edge"',
             ],
-            universal_newlines=True,
+            text=True,
         )
         self.assertEqual(foo.latest, True)
 
         foo.state = snap.SnapState.Absent
-        mock_subprocess.assert_called_with(["snap", "remove", "foo"], universal_newlines=True)
+        mock_subprocess.assert_called_with(["snap", "remove", "foo"], text=True)
 
         foo.ensure(snap.SnapState.Latest, revision="123")
         mock_subprocess.assert_called_with(
-            ["snap", "install", "foo", "--classic", '--revision="123"'], universal_newlines=True
+            ["snap", "install", "foo", "--classic", '--revision="123"'], text=True
         )
 
     @patch("charms.operator_libs_linux.v2.snap.subprocess.check_output")
@@ -372,7 +372,7 @@ class TestSnapCache(unittest.TestCase):
                 "--devmode",
                 '--cohort="A"',
             ],
-            universal_newlines=True,
+            text=True,
         )
 
         foo._refresh(leave_cohort=True)
@@ -383,7 +383,7 @@ class TestSnapCache(unittest.TestCase):
                 "foo",
                 "--leave-cohort",
             ],
-            universal_newlines=True,
+            text=True,
         )
         self.assertEqual(foo._cohort, "")
 
@@ -405,7 +405,7 @@ class TestSnapCache(unittest.TestCase):
         self.assertEqual(foo.present, True)
 
         foo.ensure(snap.SnapState.Absent)
-        mock_check_output.assert_called_with(["snap", "remove", "foo"], universal_newlines=True)
+        mock_check_output.assert_called_with(["snap", "remove", "foo"], text=True)
 
         foo.ensure(snap.SnapState.Latest, devmode=True, channel="latest/edge")
 
@@ -417,16 +417,16 @@ class TestSnapCache(unittest.TestCase):
                 "--devmode",
                 '--channel="latest/edge"',
             ],
-            universal_newlines=True,
+            text=True,
         )
         self.assertEqual(foo.latest, True)
 
         foo.state = snap.SnapState.Absent
-        mock_check_output.assert_called_with(["snap", "remove", "foo"], universal_newlines=True)
+        mock_check_output.assert_called_with(["snap", "remove", "foo"], text=True)
 
         foo.ensure(snap.SnapState.Latest, revision=123)
         mock_check_output.assert_called_with(
-            ["snap", "install", "foo", "--devmode", '--revision="123"'], universal_newlines=True
+            ["snap", "install", "foo", "--devmode", '--revision="123"'], text=True
         )
 
         with self.assertRaises(ValueError):  # devmode and classic are mutually exclusive
@@ -440,7 +440,7 @@ class TestSnapCache(unittest.TestCase):
         foo.start(["bar", "baz"], enable=True)
         mock_subprocess.assert_called_with(
             ["snap", "start", "--enable", "foo.bar", "foo.baz"],
-            universal_newlines=True,
+            text=True,
             check=True,
             capture_output=True,
         )
@@ -448,7 +448,7 @@ class TestSnapCache(unittest.TestCase):
         foo.stop(["bar"])
         mock_subprocess.assert_called_with(
             ["snap", "stop", "foo.bar"],
-            universal_newlines=True,
+            text=True,
             check=True,
             capture_output=True,
         )
@@ -456,7 +456,7 @@ class TestSnapCache(unittest.TestCase):
         foo.stop()
         mock_subprocess.assert_called_with(
             ["snap", "stop", "foo"],
-            universal_newlines=True,
+            text=True,
             check=True,
             capture_output=True,
         )
@@ -464,7 +464,7 @@ class TestSnapCache(unittest.TestCase):
         foo.logs()
         mock_subprocess.assert_called_with(
             ["snap", "logs", "-n=10", "foo"],
-            universal_newlines=True,
+            text=True,
             check=True,
             capture_output=True,
         )
@@ -472,7 +472,7 @@ class TestSnapCache(unittest.TestCase):
         foo.logs(services=["bar", "baz"], num_lines=None)
         mock_subprocess.assert_called_with(
             ["snap", "logs", "foo.bar", "foo.baz"],
-            universal_newlines=True,
+            text=True,
             check=True,
             capture_output=True,
         )
@@ -480,7 +480,7 @@ class TestSnapCache(unittest.TestCase):
         foo.restart()
         mock_subprocess.assert_called_with(
             ["snap", "restart", "foo"],
-            universal_newlines=True,
+            text=True,
             check=True,
             capture_output=True,
         )
@@ -488,7 +488,7 @@ class TestSnapCache(unittest.TestCase):
         foo.restart(["bar", "baz"], reload=True)
         mock_subprocess.assert_called_with(
             ["snap", "restart", "--reload", "foo.bar", "foo.baz"],
-            universal_newlines=True,
+            text=True,
             check=True,
             capture_output=True,
         )
@@ -510,7 +510,7 @@ class TestSnapCache(unittest.TestCase):
         foo.connect(plug="bar", slot="baz")
         mock_subprocess.assert_called_with(
             ["snap", "connect", "foo:bar", "baz"],
-            universal_newlines=True,
+            text=True,
             check=True,
             capture_output=True,
         )
@@ -518,7 +518,7 @@ class TestSnapCache(unittest.TestCase):
         foo.connect(plug="bar")
         mock_subprocess.assert_called_with(
             ["snap", "connect", "foo:bar"],
-            universal_newlines=True,
+            text=True,
             check=True,
             capture_output=True,
         )
@@ -526,7 +526,7 @@ class TestSnapCache(unittest.TestCase):
         foo.connect(plug="bar", service="baz", slot="boo")
         mock_subprocess.assert_called_with(
             ["snap", "connect", "foo:bar", "baz:boo"],
-            universal_newlines=True,
+            text=True,
             check=True,
             capture_output=True,
         )
@@ -554,7 +554,7 @@ class TestSnapCache(unittest.TestCase):
                 "foo",
                 "--hold=259200s",
             ],
-            universal_newlines=True,
+            text=True,
         )
 
     @patch("charms.operator_libs_linux.v2.snap.subprocess.check_output")
@@ -570,7 +570,7 @@ class TestSnapCache(unittest.TestCase):
                 "foo",
                 "--hold=forever",
             ],
-            universal_newlines=True,
+            text=True,
         )
 
     @patch("charms.operator_libs_linux.v2.snap.subprocess.check_output")
@@ -586,7 +586,7 @@ class TestSnapCache(unittest.TestCase):
                 "foo",
                 "--unhold",
             ],
-            universal_newlines=True,
+            text=True,
         )
 
     @patch("charms.operator_libs_linux.v2.snap.SnapClient.get_installed_snap_apps")
@@ -879,26 +879,26 @@ class TestSnapBareMethods(unittest.TestCase):
         foo = snap.add("curl", classic=True, channel="latest")
         mock_subprocess.assert_called_with(
             ["snap", "install", "curl", "--classic", '--channel="latest"'],
-            universal_newlines=True,
+            text=True,
         )
         self.assertTrue(foo.present)
         snap.add("curl", state="latest")  # cover string conversion path
         mock_subprocess.assert_called_with(
             ["snap", "refresh", "curl", '--channel="latest"'],
-            universal_newlines=True,
+            text=True,
         )
         with self.assertRaises(TypeError):  # cover error path
             snap.add(snap_names=[])
 
         bar = snap.remove("curl")
-        mock_subprocess.assert_called_with(["snap", "remove", "curl"], universal_newlines=True)
+        mock_subprocess.assert_called_with(["snap", "remove", "curl"], text=True)
         self.assertFalse(bar.present)
         with self.assertRaises(TypeError):  # cover error path
             snap.remove(snap_names=[])
 
         baz = snap.add("curl", classic=True, revision=123)
         mock_subprocess.assert_called_with(
-            ["snap", "install", "curl", "--classic", '--revision="123"'], universal_newlines=True
+            ["snap", "install", "curl", "--classic", '--revision="123"'], text=True
         )
         self.assertTrue(baz.present)
 
@@ -915,7 +915,7 @@ class TestSnapBareMethods(unittest.TestCase):
                 '--channel="latest"',
                 '--cohort="+"',
             ],
-            universal_newlines=True,
+            text=True,
         )
 
         snap.ensure("curl", "latest", classic=True, channel="latest/beta", cohort="+")
@@ -927,7 +927,7 @@ class TestSnapBareMethods(unittest.TestCase):
                 '--channel="latest/beta"',
                 '--cohort="+"',
             ],
-            universal_newlines=True,
+            text=True,
         )
 
     @patch("charms.operator_libs_linux.v2.snap.subprocess.check_output")
@@ -941,7 +941,7 @@ class TestSnapBareMethods(unittest.TestCase):
                 '--revision="233"',
                 '--cohort="+"',
             ],
-            universal_newlines=True,
+            text=True,
         )
 
         mock_check_output.reset_mock()
@@ -955,18 +955,18 @@ class TestSnapBareMethods(unittest.TestCase):
         foo = snap.ensure("curl", "latest", classic=True, channel="latest/test")
         mock_subprocess.assert_called_with(
             ["snap", "install", "curl", "--classic", '--channel="latest/test"'],
-            universal_newlines=True,
+            text=True,
         )
         self.assertTrue(foo.present)
 
         bar = snap.ensure("curl", "absent")
-        mock_subprocess.assert_called_with(["snap", "remove", "curl"], universal_newlines=True)
+        mock_subprocess.assert_called_with(["snap", "remove", "curl"], text=True)
         self.assertFalse(bar.present)
 
         baz = snap.ensure("curl", "present", classic=True, revision=123)
         mock_subprocess.assert_called_with(
             ["snap", "install", "curl", "--classic", '--revision="123"'],
-            universal_newlines=True,
+            text=True,
         )
         self.assertTrue(baz.present)
 
@@ -1090,7 +1090,7 @@ class TestSnapBareMethods(unittest.TestCase):
         self.assertEqual(foo.unset(key), "")  # pyright: ignore[reportUnknownMemberType]
         mock_subprocess.assert_called_with(
             ["snap", "unset", "foo", key],
-            universal_newlines=True,
+            text=True,
         )
 
     @patch("charms.operator_libs_linux.v2.snap.subprocess.check_call")
@@ -1098,7 +1098,7 @@ class TestSnapBareMethods(unittest.TestCase):
         snap._system_set("refresh.hold", "foobar")
         mock_subprocess.assert_called_with(
             ["snap", "set", "system", "refresh.hold=foobar"],
-            universal_newlines=True,
+            text=True,
         )
 
     @patch("charms.operator_libs_linux.v2.snap.subprocess.check_call")
@@ -1124,7 +1124,7 @@ class TestSnapBareMethods(unittest.TestCase):
         snap.hold_refresh(days=0)
         mock_subprocess.assert_called_with(
             ["snap", "set", "system", "refresh.hold="],
-            universal_newlines=True,
+            text=True,
         )
 
     @patch("charms.operator_libs_linux.v2.snap.subprocess.check_call")
@@ -1133,7 +1133,7 @@ class TestSnapBareMethods(unittest.TestCase):
 
         mock_subprocess.assert_called_with(
             ["snap", "set", "system", "refresh.hold=forever"],
-            universal_newlines=True,
+            text=True,
         )
 
     @patch("charms.operator_libs_linux.v2.snap.datetime")
@@ -1149,7 +1149,7 @@ class TestSnapBareMethods(unittest.TestCase):
 
         mock_subprocess.assert_called_with(
             ["snap", "set", "system", "refresh.hold=1970-04-01T00:00:00+00:00"],
-            universal_newlines=True,
+            text=True,
         )
 
     def test_ansi_filter(self):
@@ -1165,7 +1165,7 @@ class TestSnapBareMethods(unittest.TestCase):
         snap.install_local("./curl.snap")
         mock_subprocess.assert_called_with(
             ["snap", "install", "./curl.snap"],
-            universal_newlines=True,
+            text=True,
         )
 
     @patch("charms.operator_libs_linux.v2.snap.subprocess.check_output")
@@ -1180,7 +1180,7 @@ class TestSnapBareMethods(unittest.TestCase):
             snap.install_local("./curl.snap", **kwargs)
             mock_subprocess.assert_called_with(
                 ["snap", "install", "./curl.snap"] + cmd_args,
-                universal_newlines=True,
+                text=True,
             )
             mock_subprocess.reset_mock()
 
@@ -1215,14 +1215,14 @@ class TestSnapBareMethods(unittest.TestCase):
         foo.alias("bar", "baz")
         mock_subprocess.assert_called_once_with(
             ["snap", "alias", "foo.bar", "baz"],
-            universal_newlines=True,
+            text=True,
         )
         mock_subprocess.reset_mock()
 
         foo.alias("bar")
         mock_subprocess.assert_called_once_with(
             ["snap", "alias", "foo.bar", "bar"],
-            universal_newlines=True,
+            text=True,
         )
         mock_subprocess.reset_mock()
 
@@ -1236,7 +1236,7 @@ class TestSnapBareMethods(unittest.TestCase):
             foo.alias("bar", "baz")
         mock_subprocess.assert_called_once_with(
             ["snap", "alias", "foo.bar", "baz"],
-            universal_newlines=True,
+            text=True,
         )
         mock_subprocess.reset_mock()
 


### PR DESCRIPTION
This PR disables all the "FIXME" linting rules affecting snap.py, updating snap.py to pass linting. One change required an update to test_snap.py as well. Globally disabled "FIXME" linting rules have all been moved to per-file ignores to make it easy to see what needs fixing for each individual lib or test suite. The ruff linting config now also selects flake8-logging-format (G) to ensure that calls to logging use deferred message evaluation.

I think the file view is pretty readable, if a bit long. The commit view might be clearer, though some later commits supersede the changes made in earlier commits (e.g. f-strings commit changes were modified by the later line-length changes).