### PR TITLE
chore: bump LIBPATCH to release the snap library

### DIFF
--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -102,7 +102,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 9
+LIBPATCH = 10
 
 
 # Regex to locate 7-bit C1 ANSI sequences


### PR DESCRIPTION
This PR just bumps `LIBPATCH` to trigger a release of the `snap` lib, which should have been done in the last PR finalising the linting and typing changes for this library.