### PR TITLE
style: update type hints and enable type checking in ci for apt.py

### DIFF
--- a/lib/charms/operator_libs_linux/v0/apt.py
+++ b/lib/charms/operator_libs_linux/v0/apt.py
@@ -631,9 +631,10 @@ class Version:
                     return -1
         except IndexError:
             # a is longer than b but otherwise equal, greater unless there are tildes
-            # FIXME: type checker thinks "char" is possibly unbound -- I want to refactor this anyway
-            assert isinstance(char, str)  # pyright: ignore[reportPossiblyUnboundVariable]
-            if char == "~":
+            # FIXME: type checker thinks "char" is possibly unbound as it's a loop variable
+            #        but it won't be since the IndexError can only occur inside the loop
+            #        -- I'd like to refactor away this `try ... except` anyway
+            if char == "~":  # pyright: ignore[reportPossiblyUnboundVariable]
                 return -1
             return 1
         # if we get here, a is shorter than b but otherwise equal, so check for tildes...

--- a/lib/charms/operator_libs_linux/v0/apt.py
+++ b/lib/charms/operator_libs_linux/v0/apt.py
@@ -748,7 +748,7 @@ def add_package(
 ) -> DebianPackage: ...
 @typing.overload
 def add_package(
-    package_names: str | list[str],
+    package_names: list[str],
     version: str | None = "",
     arch: str | None = "",
     update_cache: bool = False,

--- a/lib/charms/operator_libs_linux/v0/apt.py
+++ b/lib/charms/operator_libs_linux/v0/apt.py
@@ -631,6 +631,8 @@ class Version:
                     return -1
         except IndexError:
             # a is longer than b but otherwise equal, greater unless there are tildes
+            # FIXME: type checker thinks "char" is possibly unbound -- I want to refactor this anyway
+            assert isinstance(char, str)  # pyright: ignore[reportPossiblyUnboundVariable]
             if char == "~":
                 return -1
             return 1
@@ -655,27 +657,34 @@ class Version:
                 # explicitly raise IndexError if we've fallen off the edge of list2
                 if i >= len(second_list):
                     raise IndexError
+                other = second_list[i]
                 # if the items are equal, next
-                if item == second_list[i]:
+                if item == other:
                     continue
                 # numeric comparison
                 if isinstance(item, int):
-                    if item > second_list[i]:
+                    assert isinstance(other, int)
+                    if item > other:
                         return 1
-                    if item < second_list[i]:
+                    if item < other:
                         return -1
                 else:
                     # string comparison
-                    return self._dstringcmp(item, second_list[i])
+                    assert isinstance(other, str)
+                    return self._dstringcmp(item, other)
         except IndexError:
             # rev1 is longer than rev2 but otherwise equal, hence greater
             # ...except for goddamn tildes
-            if first_list[len(second_list)][0][0] == "~":
+            # FIXME: bug?? we return 1 in both cases
+            # FIXME: first_list[len(second_list)] should be a string, why are we indexing to 0 twice?
+            if first_list[len(second_list)][0][0] == "~":  # type: ignore
                 return 1
             return 1
         # rev1 is shorter than rev2 but otherwise equal, hence lesser
         # ...except for goddamn tildes
-        if second_list[len(first_list)][0][0] == "~":
+        # FIXME: bug?? we return -1 in both cases
+        # FIXME: first_list[len(second_list)] should be a string, why are we indexing to 0 twice?
+        if second_list[len(first_list)][0][0] == "~":  # type: ignore
             return -1
         return -1
 

--- a/tox.ini
+++ b/tox.ini
@@ -53,6 +53,7 @@ commands =
     #pyright {[vars]lib_dir} {posargs}  # FIXME: enable static analysis of all libs
     #pyright {[vars]test_dir} {posargs}  # FIXME: enable static analysis of tests
     echo 'NOTE: Only manually specified libs are being static type checked currently'
+    pyright lib/charms/operator_libs_linux/v0/apt.py {posargs}
     pyright lib/charms/operator_libs_linux/v2/snap.py {posargs}
 
 [testenv:unit]


### PR DESCRIPTION
Enable static analysis of `apt.py` in ci. `LIBPATCH` will be bumped after one more follow up PR handling `ruff` linting for this lib.