### PR TITLE
chore: bump apt.py LIBPATCH for release

### DIFF
--- a/lib/charms/operator_libs_linux/v0/apt.py
+++ b/lib/charms/operator_libs_linux/v0/apt.py
@@ -124,7 +124,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 15
+LIBPATCH = 16
 
 
 VALID_SOURCE_TYPES = ("deb", "deb-src")


### PR DESCRIPTION
Let's release the apt library with its improved typing before the pulse report.