### PR TITLE
ci: add workflow_dispatch to tests for debugging flaky tests

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -2,6 +2,7 @@ name: Build/Test
 
 on:
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   lint:


### PR DESCRIPTION
This PR just adds `workflow_dispatch` to the tests so that they can be run manually for debugging purposes.