### PR TITLE
tests: fix failing integration test

### DIFF
--- a/tests/integration/test_apt.py
+++ b/tests/integration/test_apt.py
@@ -150,7 +150,7 @@ def test_install_hardware_observer_ssacli():
 
         apt.add_package(self.pkg, update_cache=True)
     """
-    line = "deb http://downloads.linux.hpe.com/SDR/repo/mcp stretch/current non-free"
+    line = "deb https://downloads.linux.hpe.com/SDR/repo/mcp stretch/current non-free"
     repo_id = apt._repo_to_identifier(  # pyright: ignore[reportPrivateUsage]
         apt.DebianRepository.from_repo_line(line, write_file=False)
     )


### PR DESCRIPTION
Known issue on hardware-observer-operator, this PR just copies the pending fix to our test:
- https://github.com/canonical/hardware-observer-operator/issues/414
- https://github.com/canonical/hardware-observer-operator/pull/415