### PR TITLE
fix: refresh with classic

### DIFF
--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -577,6 +577,9 @@ class Snap:
         if revision:
             args.append(f'--revision="{revision}"')
 
+        if self.confinement == 'classic':
+            args.append('--classic')
+
         if devmode:
             args.append("--devmode")
 


### PR DESCRIPTION
Fix a bug where `ensure` with `classic=True` doesn't add the `--classic` flag to the command.

Closes https://github.com/canonical/operator-libs-linux/issues/129.