### PR TITLE
feat: improve logging on snap error

### DIFF
--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -270,15 +270,18 @@ class SnapError(Error):
 
     @classmethod
     def _from_called_process_error(cls, msg: str, error: CalledProcessError) -> Self:
-        lines = [msg, f'stdout: {error.output!r}', f'stderr: {error.stderr!r}']
+        lines = [msg]
+        if error.stdout:
+            lines.extend(['Stdout:', error.stdout])
+        if error.stderr:
+            lines.extend(['Stderr:', error.stderr])
         try:
             cmd = ['journalctl', '--unit', 'snapd', '--lines', '20']
             logs = subprocess.check_output(cmd, text=True)
         except Exception as e:
-            lines.append(f'Error fetching logs: {e}')
+            lines.extend(['Error fetching logs:', str(e)])
         else:
-            lines.append('latest logs:')
-            lines.append(logs)
+            lines.extend(['Latest logs:', logs])
         return cls('\n'.join(lines))
 
 

--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -102,7 +102,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 11
+LIBPATCH = 12
 
 
 # Regex to locate 7-bit C1 ANSI sequences

--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -275,7 +275,7 @@ class SnapError(Error):
             cmd = ['journalctl', '--unit', 'snapd', '--lines', '20']
             logs = subprocess.check_output(cmd, text=True)
         except Exception as e:
-            lines.append(f'unable to retrieve logs due to {e}')
+            lines.append(f'Error fetching logs: {e}')
         else:
             lines.append('latest logs:')
             lines.append(logs)

--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -353,7 +353,7 @@ class Snap:
         optargs = optargs or []
         args = ["snap", command, self._name, *optargs]
         try:
-            return subprocess.check_output(args, text=True)
+            return subprocess.check_output(args, text=True, stderr=subprocess.PIPE)
         except CalledProcessError as e:
             msg = f'Snap: {self._name!r} -- command {args!r} failed!'
             raise SnapError._from_called_process_error(msg=msg, error=e) from e
@@ -520,7 +520,7 @@ class Snap:
             alias = application
         args = ["snap", "alias", f"{self.name}.{application}", alias]
         try:
-            subprocess.check_output(args, text=True)
+            subprocess.run(args, text=True, check=True, capture_output=True)
         except CalledProcessError as e:
             msg = f'Snap: {self._name!r} -- command {args!r} failed!'
             raise SnapError._from_called_process_error(msg=msg, error=e) from e
@@ -1277,7 +1277,7 @@ def install_local(
     if dangerous:
         args.append("--dangerous")
     try:
-        result = subprocess.check_output(args, text=True).splitlines()[-1]
+        result = subprocess.check_output(args, text=True, stderr=subprocess.PIPE).splitlines()[-1]
         snap_name, _ = result.split(" ", 1)
         snap_name = ansi_filter.sub("", snap_name)
 
@@ -1306,7 +1306,7 @@ def _system_set(config_item: str, value: str) -> None:
     """
     args = ["snap", "set", "system", f"{config_item}={value}"]
     try:
-        subprocess.check_call(args, text=True)
+        subprocess.run(args, text=True, check=True, capture_output=True)
     except CalledProcessError as e:
         msg = f"Failed setting system config '{config_item}' to '{value}'"
         raise SnapError._from_called_process_error(msg=msg, error=e) from e

--- a/tests/integration/test_snap.py
+++ b/tests/integration/test_snap.py
@@ -170,7 +170,7 @@ def test_unset_key_raises_snap_error():
     with pytest.raises(snap.SnapError) as ctx:
         lxd.get(key)
     assert key in ctx.value.message
-    assert "\nlatest logs:\n" in ctx.value.message  # journalctl log retrieval on SnapError
+    assert "\nLatest logs:\n" in ctx.value.message  # journalctl log retrieval on SnapError
 
     # We can make the above work w/ arbitrary config.
     lxd.set({key: "true"})

--- a/tests/integration/test_snap.py
+++ b/tests/integration/test_snap.py
@@ -167,12 +167,10 @@ def test_unset_key_raises_snap_error():
 
     # Verify that the correct exception gets raised in the case of an unset key.
     key = "keythatdoesntexist01"
-    try:
+    with pytest.raises(snap.SnapError) as ctx:
         lxd.get(key)
-    except snap.SnapError:
-        pass
-    else:
-        logger.error("Getting an unset key should result in a SnapError.")
+    assert key in ctx.value.message
+    assert "\nlatest logs:\n" in ctx.value.message  # journalctl log retrieval on SnapError
 
     # We can make the above work w/ arbitrary config.
     lxd.set({key: "true"})


### PR DESCRIPTION
When a `SnapError` is raised after a `snap` command errors (raising a `CalledProcessError`), the error does not currently contain the process's `stderr`. Additionally, the failure information may not be present in `stdout` or `stderr`, but may instead have been logged to the journal. This PR updates the 6 call sites where a `CalledProcessError` is converted to a `SnapError` as follows:
- The `subprocess` call is updated to always capture `stdout` and `stderr` so that these are available in the `CalledProcessError`
- The specific error message and the `CalledProcessError` are passed to a new constructor for `SnapError`
- `SnapError._from_called_process_error` extends the provided message with `stdout` and `stderr` from the `CalledProcessError`, and attempts to extend it further with the last 20 entries from the journal from the `snapd` unit -- if this fails, the failure is appended to the message instead

The unit tests have been updated due to the changes to the `subprocess` calls. The functional change is exercised in an integration test, which has been updated to be more strict (previously it could pass even if the expected error wasn't raised), and to check that the logs have been retrieved successfully.

Fixes: #136

This is an example of the new error output (captured by forcing re-raising the exception caught in the integration test):
```
charms.operator_libs_linux.v2.snap.SnapError: Snap: 'lxd' -- command ['snap', 'get', 'lxd', 'keythatdoesntexist01'] failed!
Stderr:
error: snap "lxd" has no "keythatdoesntexist01" configuration option

Latest logs:
Jun 06 04:29:35 fv-az1721-795 snapd[21730]: storehelpers.go:954: cannot refresh snap "snapd": snap has no updates available
Jun 06 04:29:35 fv-az1721-795 snapd[21730]: overlord.go:518: Released state lock file
Jun 06 04:29:35 fv-az1721-795 systemd[1]: snapd.service: Deactivated successfully.
Jun 06 04:29:35 fv-az1721-795 systemd[1]: snapd.service: Scheduled restart job, restart counter is at 1.
Jun 06 04:29:35 fv-az1721-795 systemd[1]: Starting snapd.service - Snap Daemon...
Jun 06 04:29:36 fv-az1721-795 snapd[22044]: overlord.go:284: Acquiring state lock file
Jun 06 04:29:36 fv-az1721-795 snapd[22044]: overlord.go:289: Acquired state lock file
Jun 06 04:29:36 fv-az1721-795 snapd[22044]: patch.go:64: Patching system state level 6 to sublevel 1...
Jun 06 04:29:36 fv-az1721-795 snapd[22044]: patch.go:64: Patching system state level 6 to sublevel 2...
Jun 06 04:29:36 fv-az1721-795 snapd[22044]: patch.go:64: Patching system state level 6 to sublevel 3...
Jun 06 04:29:36 fv-az1721-795 snapd[22044]: daemon.go:250: started snapd/2.68.4 (series 16; classic) ubuntu/24.04 (amd64) linux/6.11.0-1015-azure.
Jun 06 04:29:36 fv-az1721-795 snapd[22044]: daemon.go:353: adjusting startup timeout by 35s (pessimistic estimate of 30s plus 5s per snap)
Jun 06 04:29:36 fv-az1721-795 snapd[22044]: backends.go:91: AppArmor status: apparmor is enabled and all features are available (using snapd provided apparmor_parser)
Jun 06 04:29:37 fv-az1721-795 systemd[1]: Started snapd.service - Snap Daemon.
Jun 06 04:29:45 fv-az1721-795 snapd[22044]: api_snaps.go:467: Installing snap "charmcraft" revision unset
Jun 06 04:29:56 fv-az1721-795 snapd[22044]: api_snaps.go:467: Installing snap "hello-world" revision unset
Jun 06 04:30:01 fv-az1721-795 snapd[22044]: storehelpers.go:916: cannot refresh snap "hello-world": snap has no updates available
Jun 06 04:30:02 fv-az1721-795 snapd[22044]: api_snaps.go:467: Installing snap "lxd" revision unset
Jun 06 04:30:13 fv-az1721-795 snapd[22044]: storehelpers.go:916: cannot refresh snap "lxd": snap has no updates available
Jun 06 04:30:14 fv-az1721-795 snapd[22044]: storehelpers.go:916: cannot refresh snap "lxd": snap has no updates available
```