### PR TITLE
feat: track snap version

### DIFF
--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -309,8 +309,8 @@ class Snap:
       - state: a `SnapState` representation of its install status
       - channel: "stable", "candidate", "beta", and "edge" are common
       - revision: a string representing the snap's revision
-      - version: a string representing the snap's version
       - confinement: "classic", "strict", or "devmode"
+      - version: a string representing the snap's version, if set by the snap author
     """
 
     def __init__(
@@ -319,19 +319,20 @@ class Snap:
         state: SnapState,
         channel: str,
         revision: str,
-        version: str,
         confinement: str,
         apps: list[dict[str, JSONType]] | None = None,
         cohort: str | None = None,
+        *,
+        version: str | None = None,
     ) -> None:
         self._name = name
         self._state = state
         self._channel = channel
         self._revision = revision
-        self._version = version
         self._confinement = confinement
         self._cohort = cohort or ""
         self._apps = apps or []
+        self._version = version
         self._snap_client = SnapClient()
 
     def __eq__(self, other: object) -> bool:
@@ -754,11 +755,6 @@ class Snap:
         return self._revision
 
     @property
-    def version(self) -> str:
-        """Returns the version for a snap."""
-        return self._version
-
-    @property
     def channel(self) -> str:
         """Returns the channel for a snap."""
         return self._channel
@@ -791,6 +787,11 @@ class Snap:
         """Report whether the snap has a hold."""
         info = self._snap("info")
         return "hold:" in info
+
+    @property
+    def version(self) -> str | None:
+        """Returns the version for a snap."""
+        return self._version
 
 
 class _UnixSocketConnection(http.client.HTTPConnection):
@@ -1055,9 +1056,9 @@ class SnapCache(Mapping[str, Snap]):
                 state=SnapState.Latest,
                 channel=i["channel"],
                 revision=i["revision"],
-                version=i["version"],
                 confinement=i["confinement"],
                 apps=i.get("apps"),
+                version=i.get("version"),
             )
             self._snap_map[snap.name] = snap
 
@@ -1075,9 +1076,9 @@ class SnapCache(Mapping[str, Snap]):
             state=SnapState.Available,
             channel=info["channel"],
             revision=info["revision"],
-            version=info["version"],
             confinement=info["confinement"],
             apps=None,
+            version=info.get("version"),
         )
 
 

--- a/tests/integration/test_snap.py
+++ b/tests/integration/test_snap.py
@@ -204,12 +204,14 @@ def test_snap_ensure_revision():
         ["snap", "info", "juju"], capture_output=True, encoding="utf-8"
     ).stdout.split("\n")
 
+    edge_version = None
     edge_revision = None
     for line in snap_info_juju:
-        match = re.search(r"3/stable.*\((\d+)\)", line)
+        match = re.search(r"3/stable:\s+([^\s]+).+\((\d+)\)", line)
 
         if match:
-            edge_revision = match.group(1)
+            edge_version = match.group(1)
+            edge_revision = match.group(2)
             break
     assert edge_revision is not None
 
@@ -226,10 +228,13 @@ def test_snap_ensure_revision():
     assert "installed" in snap_info_juju
     for line in snap_info_juju.split("\n"):
         if "installed" in line:
-            match = re.search(r"installed.*\((\d+)\)", line)
+            match = re.search(r"installed:\s+([^\s]+).+\((\d+)\)", line)
 
             assert match is not None
-            assert match.group(1) == edge_revision
+            assert match.group(1) == edge_version
+            assert match.group(2) == edge_revision
+
+    assert juju.version == edge_version
 
 
 def test_snap_start():

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -291,6 +291,7 @@ class TestSnapCache(unittest.TestCase):
         self.assertEqual(result.channel, "stable")
         self.assertEqual(result.confinement, "strict")
         self.assertEqual(result.revision, "233")
+        self.assertEqual(result.version, "7.78.0")
 
     @patch("os.path.isfile")
     def test_can_load_installed_snap_info(self, mock_exists):
@@ -326,12 +327,17 @@ class TestSnapCache(unittest.TestCase):
         self.assertIn("snapd is not running", ctx.exception.message)
 
     def test_can_compare_snap_equality(self):
-        foo1 = snap.Snap("foo", snap.SnapState.Present, "stable", "1", "v42", "classic")
-        foo2 = snap.Snap("foo", snap.SnapState.Present, "stable", "1", "v42", "classic")
+        foo1 = snap.Snap("foo", snap.SnapState.Present, "stable", "1", "classic", version="v42")
+        foo2 = snap.Snap("foo", snap.SnapState.Present, "stable", "1", "classic")
         self.assertEqual(foo1, foo2)
 
+    def test_can_compare_snap_inequality(self):
+        foo1 = snap.Snap("foo", snap.SnapState.Present, "stable", "1", "classic", version="v42")
+        foo2 = snap.Snap("foo", snap.SnapState.Present, "stable", "2", "classic", version="v42")
+        self.assertNotEqual(foo1, foo2)
+
     def test_snap_magic_methods(self):
-        foo = snap.Snap("foo", snap.SnapState.Present, "stable", "1", "v42", "classic")
+        foo = snap.Snap("foo", snap.SnapState.Present, "stable", "1", "classic")
         self.assertEqual(hash(foo), hash((foo._name, foo._revision)))
         str(foo)  # ensure custom __str__ doesn't error
         repr(foo)  # ensure custom __repr__ doesn't error
@@ -339,7 +345,7 @@ class TestSnapCache(unittest.TestCase):
     @patch("charms.operator_libs_linux.v2.snap.subprocess.check_output")
     def test_can_run_snap_commands(self, mock_subprocess: MagicMock):
         mock_subprocess.return_value = 0
-        foo = snap.Snap("foo", snap.SnapState.Present, "stable", "1", "v42", "classic")
+        foo = snap.Snap("foo", snap.SnapState.Present, "stable", "1", "classic")
         self.assertEqual(foo.present, True)
         foo.state = snap.SnapState.Present
         mock_subprocess.assert_not_called()
@@ -384,7 +390,6 @@ class TestSnapCache(unittest.TestCase):
             state=snap.SnapState.Present,
             channel="stable",
             revision="1",
-            version="v42",
             confinement="devmode",
             apps=None,
             cohort="A",
@@ -419,7 +424,7 @@ class TestSnapCache(unittest.TestCase):
     @patch("charms.operator_libs_linux.v2.snap.subprocess.check_output")
     def test_no_subprocess_when_not_installed(self, mock_subprocess: MagicMock):
         """Don't call out to snap when ensuring an uninstalled state when not installed."""
-        foo = snap.Snap("foo", snap.SnapState.Present, "stable", "1", "v42", "classic")
+        foo = snap.Snap("foo", snap.SnapState.Present, "stable", "1", "classic")
         not_installed_states = (snap.SnapState.Absent, snap.SnapState.Available)
         for _state in not_installed_states:
             foo._state = _state
@@ -430,7 +435,7 @@ class TestSnapCache(unittest.TestCase):
     @patch("charms.operator_libs_linux.v2.snap.subprocess.check_output")
     def test_can_run_snap_commands_devmode(self, mock_check_output: MagicMock):
         mock_check_output.return_value = 0
-        foo = snap.Snap("foo", snap.SnapState.Present, "stable", "1", "v42", "devmode")
+        foo = snap.Snap("foo", snap.SnapState.Present, "stable", "1", "devmode")
         self.assertEqual(foo.present, True)
 
         foo.ensure(snap.SnapState.Absent)
@@ -471,7 +476,7 @@ class TestSnapCache(unittest.TestCase):
     @patch("charms.operator_libs_linux.v2.snap.subprocess.run")
     def test_can_run_snap_daemon_commands(self, mock_subprocess):
         mock_subprocess.return_value = MagicMock()
-        foo = snap.Snap("foo", snap.SnapState.Latest, "stable", "1", "v42", "classic")
+        foo = snap.Snap("foo", snap.SnapState.Latest, "stable", "1", "classic")
 
         foo.start(["bar", "baz"], enable=True)
         mock_subprocess.assert_called_with(
@@ -534,14 +539,14 @@ class TestSnapCache(unittest.TestCase):
         side_effect=CalledProcessError(returncode=1, cmd=""),
     )
     def test_snap_daemon_commands_raise_snap_error(self, mock_subprocess: MagicMock):
-        foo = snap.Snap("foo", snap.SnapState.Latest, "stable", "1", "v42", "classic")
+        foo = snap.Snap("foo", snap.SnapState.Latest, "stable", "1", "classic")
         with self.assertRaises(snap.SnapError):
             foo.start(["bad", "arguments"], enable=True)
 
     @patch("charms.operator_libs_linux.v2.snap.subprocess.run")
     def test_snap_connect(self, mock_subprocess):
         mock_subprocess.return_value = MagicMock()
-        foo = snap.Snap("foo", snap.SnapState.Latest, "stable", "1", "v42", "classic")
+        foo = snap.Snap("foo", snap.SnapState.Latest, "stable", "1", "classic")
 
         foo.connect(plug="bar", slot="baz")
         mock_subprocess.assert_called_with(
@@ -573,14 +578,14 @@ class TestSnapCache(unittest.TestCase):
     )
     def test_snap_connect_raises_snap_error(self, mock_subprocess: MagicMock):
         """Ensure that a SnapError is raised when Snap.connect is called with bad arguments."""
-        foo = snap.Snap("foo", snap.SnapState.Latest, "stable", "1", "v42", "classic")
+        foo = snap.Snap("foo", snap.SnapState.Latest, "stable", "1", "classic")
         with self.assertRaises(snap.SnapError):
             foo.connect(plug="bad", slot="argument")
 
     @patch("charms.operator_libs_linux.v2.snap.subprocess.check_output")
     def test_snap_hold_timedelta(self, mock_check_output: MagicMock):
         mock_check_output.return_value = 0
-        foo = snap.Snap("foo", snap.SnapState.Latest, "stable", "1", "v42", "classic")
+        foo = snap.Snap("foo", snap.SnapState.Latest, "stable", "1", "classic")
 
         foo.hold(duration=datetime.timedelta(hours=72))
         mock_check_output.assert_called_with(
@@ -597,7 +602,7 @@ class TestSnapCache(unittest.TestCase):
     @patch("charms.operator_libs_linux.v2.snap.subprocess.check_output")
     def test_snap_hold_forever(self, mock_subprocess: MagicMock):
         mock_subprocess.return_value = 0
-        foo = snap.Snap("foo", snap.SnapState.Latest, "stable", "1", "v42", "classic")
+        foo = snap.Snap("foo", snap.SnapState.Latest, "stable", "1", "classic")
 
         foo.hold()
         mock_subprocess.assert_called_with(
@@ -614,7 +619,7 @@ class TestSnapCache(unittest.TestCase):
     @patch("charms.operator_libs_linux.v2.snap.subprocess.check_output")
     def test_snap_unhold(self, mock_subprocess: MagicMock):
         mock_subprocess.return_value = 0
-        foo = snap.Snap("foo", snap.SnapState.Latest, "stable", "1", "v42", "classic")
+        foo = snap.Snap("foo", snap.SnapState.Latest, "stable", "1", "classic")
 
         foo.unhold()
         mock_subprocess.assert_called_with(
@@ -683,7 +688,6 @@ def test_refresh_classic(
         state=snap.SnapState.Present,
         channel='stable',
         revision='1',
-        version='v42',
         confinement=confinement,
         apps=None,
         cohort='A',
@@ -1132,7 +1136,7 @@ class TestSnapBareMethods(unittest.TestCase):
                 return json.dumps({})
             raise snap.SnapError("Bad arguments:", command, optargs)
 
-        foo = snap.Snap("foo", snap.SnapState.Latest, "stable", "1", "v42", "classic")
+        foo = snap.Snap("foo", snap.SnapState.Latest, "stable", "1", "classic")
         foo._snap = MagicMock(side_effect=fake_snap)
         keys_and_values: dict[str, Any] = {
             "key_w_string_value": "string",
@@ -1156,7 +1160,7 @@ class TestSnapBareMethods(unittest.TestCase):
 
     @patch("charms.operator_libs_linux.v2.snap.SnapClient._put_snap_conf")
     def test_snap_set_typed(self, put_snap_conf):
-        foo = snap.Snap("foo", snap.SnapState.Present, "stable", "1", "v42", "classic")
+        foo = snap.Snap("foo", snap.SnapState.Present, "stable", "1", "classic")
 
         config = {"n": 42, "s": "string", "d": {"nested": True}}
 
@@ -1165,7 +1169,7 @@ class TestSnapBareMethods(unittest.TestCase):
 
     @patch("charms.operator_libs_linux.v2.snap.SnapClient._put_snap_conf")
     def test_snap_set_untyped(self, put_snap_conf):
-        foo = snap.Snap("foo", snap.SnapState.Present, "stable", "1", "v42", "classic")
+        foo = snap.Snap("foo", snap.SnapState.Present, "stable", "1", "classic")
 
         config = {"n": 42, "s": "string", "d": {"nested": True}}
 
@@ -1179,7 +1183,7 @@ class TestSnapBareMethods(unittest.TestCase):
         side_effect=lambda *args, **kwargs: "",  # pyright: ignore[reportUnknownLambdaType]
     )
     def test_snap_unset(self, mock_subprocess: MagicMock):
-        foo = snap.Snap("foo", snap.SnapState.Present, "stable", "1", "v42", "classic")
+        foo = snap.Snap("foo", snap.SnapState.Present, "stable", "1", "classic")
         key: str = "test_key"
         self.assertEqual(foo.unset(key), "")
         mock_subprocess.assert_called_with(
@@ -1317,7 +1321,7 @@ class TestSnapBareMethods(unittest.TestCase):
 
     @patch("charms.operator_libs_linux.v2.snap.subprocess.run")
     def test_alias(self, mock_run: MagicMock):
-        foo = snap.Snap("foo", snap.SnapState.Latest, "stable", "1", "v42", "classic")
+        foo = snap.Snap("foo", snap.SnapState.Latest, "stable", "1", "classic")
         foo.alias("bar", "baz")
         mock_run.assert_called_once_with(
             ["snap", "alias", "foo.bar", "baz"],
@@ -1341,7 +1345,7 @@ class TestSnapBareMethods(unittest.TestCase):
         mock_run.side_effect = CalledProcessError(
             returncode=1, cmd=["snap", "alias", "foo.bar", "baz"]
         )
-        foo = snap.Snap("foo", snap.SnapState.Latest, "stable", "1", "v42", "classic")
+        foo = snap.Snap("foo", snap.SnapState.Latest, "stable", "1", "classic")
         with self.assertRaises(snap.SnapError):
             foo.alias("bar", "baz")
         mock_run.assert_any_call(
@@ -1354,7 +1358,7 @@ class TestSnapBareMethods(unittest.TestCase):
 
     @patch("charms.operator_libs_linux.v2.snap.subprocess.check_output")
     def test_held(self, mock_subprocess: MagicMock):
-        foo = snap.Snap("foo", snap.SnapState.Latest, "stable", "1", "v42", "classic")
+        foo = snap.Snap("foo", snap.SnapState.Latest, "stable", "1", "classic")
         mock_subprocess.return_value = {}
         self.assertEqual(foo.held, False)
         mock_subprocess.return_value = {"hold:": "key isn't checked"}


### PR DESCRIPTION
Keep track of the snap version, if such version is available so that it could be used from a charm to set the workload version. 

For example, an operator charm could set the version like this:

```py
def _on_start(self, _event: ops.StartEvent) -> None:
    self.unit.status = ops.MaintenanceStatus("starting...")
    maas = SnapCache()["maas"]
    workload_version = maas.version if maas.version is not None else maas.revision
    self.unit.set_workload_version(workload_version)
```