### PR TITLE
feat: add support for passing "all" arg to snap.logs

### DIFF
--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -480,7 +480,7 @@ class Snap:
         args = ["stop", "--disable"] if disable else ["stop"]
         self._snap_daemons(args, services)
 
-    def logs(self, services: list[str] | None = None, num_lines: int = 10) -> str:
+    def logs(self, services: list[str] | None = None, num_lines: int | Literal["all"] = 10) -> str:
         """Fetch a snap services' logs.
 
         Args:

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -510,6 +510,14 @@ class TestSnapCache(unittest.TestCase):
             capture_output=True,
         )
 
+        foo.logs(num_lines='all')
+        mock_subprocess.assert_called_with(
+            ["snap", "logs", "-n=all", "foo"],
+            text=True,
+            check=True,
+            capture_output=True,
+        )
+
         foo.logs(services=["bar", "baz"], num_lines=None)
         mock_subprocess.assert_called_with(
             ["snap", "logs", "foo.bar", "foo.baz"],


### PR DESCRIPTION
the `snap logs` command supports an `all` parameter for the `-n` flag.

```
# from the command's own --help:
[logs command options]
          --abs-time   Display absolute times (in RFC 3339 format). Otherwise, display relative times up to 60 days, then YYYY-MM-DD.
      -n=              Show only the given number of lines, or 'all'. (default: 10)
      -f               Wait for new lines and print them as they come in.

```
This PR adds support for that (in the form of a type hint correction, the implementation is unchanged).