### PR TITLE
Make wrap_snap_operations return the actual error.

### DIFF
--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -1288,10 +1288,10 @@ def _wrap_snap_operations(
             snaps.append(snap)
         except SnapError as e:  # noqa: PERF203
             logger.warning("Failed to %s snap %s: %s!", op, s, e.message)
-            errors.append(s)
+            errors.append(e.message)
         except SnapNotFoundError:
             logger.warning("Snap '%s' not found in cache!", s)
-            errors.append(s)
+            errors.append(f"Snap '{s}' not found in cache!")
 
     if errors:
         raise SnapError(f"Failed to install or refresh snap(s): {', '.join(errors)}")

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -1095,7 +1095,10 @@ class TestSnapBareMethods(unittest.TestCase):
                 snap.add("nothere")
         repr(ctx.exception)  # ensure custom __repr__ doesn't error
         self.assertEqual("<charms.operator_libs_linux.v2.snap.SnapError>", ctx.exception.name)
-        self.assertIn("Failed to install or refresh snap(s): nothere", ctx.exception.message)
+        self.assertIn(
+            "Failed to install or refresh snap(s): Snap 'nothere' not found in cache!",
+            ctx.exception.message,
+        )
 
     def test_snap_get(self):
         """Test the multiple different ways of calling the Snap.get function.


### PR DESCRIPTION
Currently wrap_snap_operations just returns minimal error messages including only the names of the snaps that failed and not why. This is not particularly useful so I've expanded this to return include the actual error as well.